### PR TITLE
Fix start script on newer macs and sync 32bit to 64bit version

### DIFF
--- a/build/jameica-macos.sh
+++ b/build/jameica-macos.sh
@@ -5,18 +5,29 @@
 
 TERM="xterm"
 
-JAVACMD="/usr/libexec/java_home/../java"
+JAVACMD="$JAVA_HOME/bin/java"
 
+# use Apple's "/usr/libexec/java_home" utility to get installed JVMs
+if [ ! -x $JAVACMD ] && [ -x /usr/libexec/java_home ] && /usr/libexec/java_home -F 2> /dev/null; then
+	JAVACMD="`/usr/libexec/java_home 2> /dev/null`/bin/java"
+fi
+
+# Siehe Mail von Volker vom 31.12.2014
 if [ ! -x "$JAVACMD" ]; then
   JAVACMD="/System/Library/Frameworks/JavaVM.framework/Versions/Current/Commands/java"
 fi
 
-# Java 7 - siehe http://docs.oracle.com/javase/7/docs/webnotes/install/mac/mac-jre.html
-# BUGZILLA 1337 - Gott, deren Pfad-Angaben werden ja auch immer schlimmer
-if [ ! -x "$JAVACMD" ]; then
-  JAVACMD="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java"
+# try old Apple Java
+if [ ! -x $JAVACMD ] && [ -h /Library/Java/Home ]; then
+	JAVACMD="/Library/Java/Home/bin/java"
 fi
 
+# try Oracle JRE (which now only is installed as internet plugin)
+if [ ! -x $JAVACMD ]; then
+	JAVACMD="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java"
+fi
+
+# last resort - does not really help on mac as java in $PATH is a wrapper
 if [ ! -x "$JAVACMD" ]; then
   JAVACMD="`which java`"
 fi

--- a/build/jameica-macos64.sh
+++ b/build/jameica-macos64.sh
@@ -5,12 +5,11 @@
 
 TERM="xterm"
 
-JAVACMD="/usr/libexec/java_home/../java"
+JAVACMD="$JAVA_HOME/bin/java"
 
-# Java 7 - siehe http://docs.oracle.com/javase/7/docs/webnotes/install/mac/mac-jre.html
-# BUGZILLA 1337 - Gott, deren Pfad-Angaben werden ja auch immer schlimmer
-if [ ! -x "$JAVACMD" ]; then
-  JAVACMD="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java"
+# use Apple's "/usr/libexec/java_home" utility to get installed JVMs
+if [ ! -x $JAVACMD ] && [ -x /usr/libexec/java_home ] && /usr/libexec/java_home -F 2> /dev/null; then
+	JAVACMD="`/usr/libexec/java_home 2> /dev/null`/bin/java"
 fi
 
 # Siehe Mail von Volker vom 31.12.2014
@@ -18,6 +17,17 @@ if [ ! -x "$JAVACMD" ]; then
   JAVACMD="/System/Library/Frameworks/JavaVM.framework/Versions/Current/Commands/java"
 fi
 
+# try old Apple Java
+if [ ! -x $JAVACMD ] && [ -h /Library/Java/Home ]; then
+	JAVACMD="/Library/Java/Home/bin/java"
+fi
+
+# try Oracle JRE (which now only is installed as internet plugin)
+if [ ! -x $JAVACMD ]; then
+	JAVACMD="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java"
+fi
+
+# last resort - does not really help on mac as java in $PATH is a wrapper
 if [ ! -x "$JAVACMD" ]; then
   JAVACMD="`which java`"
 fi


### PR DESCRIPTION
Make JVM detection on Mac working again. Should now work with old Java
6, newer Oracle JDKs and fall back to Oracle JRE which installs itself
only as internet plugin.