### PR TITLE
multi-user safety: script for linux 64, mac, windows

### DIFF
--- a/build/multi-user-jameica-linux64.sh
+++ b/build/multi-user-jameica-linux64.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Nachfolgende drei Zeilen bitte anpassen
+# JAMEICA_DATADIR muss angegeben werden, selbst wenn der Standard-Pfad verwendet wird. 
+#    Es reicht dabei den Pfad bis zur jameica.app anzupassen, falls notwendig.
+JAMEICA_APP_PATH="/Applications/jameica.app/"
+# Pfad zu dem Ort, an dem der jameica-Benutzerordner liegt. Ersetze <DeinUserName> durch Deinen Mac-Benutzernamen. 
+#    Eine Liste aller Benutzer kann man sehen, wenn man unter /Users bzw. 
+#    /Benutzer sich die dort liegenden Ordner ansieht.
+JAMEICA_DATADIR="/Users/<DeinUserName>/Desktop/jameica/"
+# Kopiert aus dem Original jameica-Startskript. Entspricht dem Standard aus OSX 10.10
+JAVACMD="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java"
+
+######################################### Ab hier keine Änderungen mehr notwendig
+LOCKFILE_MY="${JAMEICA_DATADIR}/my.lock"
+# Prüfen, ob Lockfile existiert
+if [ -f "$LOCKFILE_MY" ];then #Jameica in Verwendung, da Lock-File existiert
+   JAMEICA_USER=$(cat $LOCKFILE_MY)
+   echo "**********"
+   echo "* Jameica wird gerade benutzt von"
+   echo "*      $JAMEICA_USER"
+   echo "**********"
+   echo "* Jameica kann erst gestartet"
+   echo "* werden, wenn obiger Benutzer das"
+   echo "* Programm beendet hat."
+   echo "**********"
+else #Jameica nicht in Verwendung, da das Lock-File nicht existiert
+   echo "**********"
+   echo "* Jameica wird gestartet"
+   echo "**********"
+   echo "* ACHTUNG:"
+   echo "*    Dieses Fenster NICHT schließen, es wird"
+   echo "*    automatisch geschlossen sobald Jameica"
+   echo "*    beendet wurde."
+   echo "**********"
+   echo "${USER}@${HOSTNAME}\r\n" > $LOCKFILE_MY
+   # In das .app-Verzeichnis wechseln
+   cd $JAMEICA_APP_PATH
+   # Jameica nicht über die jameica.app aufrufen sondern mit java das JAR-Archiv aufrufen
+   # da sonst der Batch gleich weiterläuft und nicht wartet bis Jameica beendet wurde.
+   java -Xmx256m -jar jameica-linux64.jar $@ > access.log
+   rm -f $LOCKFILE_MY
+fi

--- a/build/multi-user-jameica-macos.sh
+++ b/build/multi-user-jameica-macos.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# source: http://www.jverein.de/wiki/index.php?title=Multiuser#Multiuser-Setup_per_SVN.2FSubversion
+
+# Nachfolgende drei Zeilen bitte anpassen
+# JAMEICA_DATADIR muss angegeben werden, selbst wenn der Standard-Pfad verwendet wird. 
+#    Es reicht dabei den Pfad bis zur jameica.app anzupassen, falls notwendig.
+JAMEICA_APP_PATH="/Applications/jameica.app/"
+# Pfad zu dem Ort, an dem der jameica-Benutzerordner liegt. Ersetze <DeinUserName> durch Deinen Mac-Benutzernamen. 
+#    Eine Liste aller Benutzer kann man sehen, wenn man unter /Users bzw. 
+#    /Benutzer sich die dort liegenden Ordner ansieht.
+JAMEICA_DATADIR="/Users/<DeinUserName>/Desktop/jameica/"
+# Kopiert aus dem Original jameica-Startskript. Entspricht dem Standard aus OSX 10.10
+JAVACMD="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java"
+
+######################################### Ab hier keine Änderungen mehr notwendig
+LOCKFILE_MY="${JAMEICA_DATADIR}/my.lock"
+# Prüfen, ob Lockfile existiert
+if [ -f "$LOCKFILE_MY" ];then #Jameica in Verwendung, da Lock-File existiert
+   JAMEICA_USER=$(cat $LOCKFILE_MY)
+   echo "**********"
+   echo "* Jameica wird gerade benutzt von"
+   echo "*      $JAMEICA_USER"
+   echo "**********"
+   echo "* Jameica kann erst gestartet"
+   echo "* werden, wenn obiger Benutzer das"
+   echo "* Programm beendet hat."
+   echo "**********"
+else #Jameica nicht in Verwendung, da das Lock-File nicht existiert
+   echo "**********"
+   echo "* Jameica wird gestartet"
+   echo "**********"
+   echo "* ACHTUNG:"
+   echo "*    Dieses Fenster NICHT schließen, es wird"
+   echo "*    automatisch geschlossen sobald Jameica"
+   echo "*    beendet wurde."
+   echo "**********"
+   echo "${USER}@${HOSTNAME}\r\n" > $LOCKFILE_MY
+   # In das .app-Verzeichnis wechseln
+   cd $JAMEICA_APP_PATH
+   # Jameica nicht über die jameica.app aufrufen sondern mit java das JAR-Archiv aufrufen
+   # da sonst der Batch gleich weiterläuft und nicht wartet bis Jameica beendet wurde.
+   $("${JAVACMD}" -Xdock:name="Jameica" -Xmx256m -XstartOnFirstThread -jar "${JAMEICA_APP_PATH}/jameica-macos64.jar" -f "${JAMEICA_DATADIR}" -o "$@" > /dev/null) > /dev/null
+   rm -f $LOCKFILE_MY
+fi

--- a/build/multi-user-jameica-windows.sh
+++ b/build/multi-user-jameica-windows.sh
@@ -1,0 +1,50 @@
+@echo off
+rem Quelle: http://www.jverein.de/wiki/index.php?title=Multiuser#Multiuser-Setup_per_SVN.2FSubversion
+rem Nachfolgende drei set-Zeilen bitte anpassen
+rem JAMEICA_DATADIR muss angegeben werden, selbst wenn der Standard-Pfad verwendet wird
+rem JAMEICA_3264 muss -je nach eigener Umgebung- auf 32 oder 64 eingestellt werden
+set JAMEICA_PROGDIR=C:\Program Files (x86)\jameica\
+set JAMEICA_DATADIR=C:\Users\<DeinBenutzername>\Documents\jameica\
+set JAMEICA_3264=32
+rem
+rem Ab hier keine Änderungen mehr nötig
+set JAMEICA_BIN=jameica-win32.exe
+set JAMEICA_JAR=jameica-win32.jar
+if %JAMEICA_3264%==64 (
+  set JAMEICA_BIN=jameica-win64.exe
+  set JAMEICA_JAR=jameica-win64.jar
+)
+set LOCKFILE_MY="%JAMEICA_DATADIR%\my.lock"
+rem Prüfen ob Lockfile exitiert
+if exist %LOCKFILE_MY% goto jameica_in_use
+  goto jameica_start
+:jameica_start
+echo **********
+echo * Jameica wird gestartet
+echo **********
+echo * ACHTUNG:
+echo *    Dieses Fenster NICHT schliessen, es wird
+echo *    automatisch geschlossen sobald Jameica
+echo *    beendet wurde.
+echo **********
+echo %USERNAME%@%COMPUTERNAME% > %LOCKFILE_MY%
+rem Jameica nicht mit der Starter-EXE aufrufen sondern mit javaw das JAR-Archiv aufrufen
+rem da sonst der Batch gleich weiterläuft und nicht wartet bis Jameica beendet wurde.
+cd %JAMEICA_PROGDIR%
+javaw -jar "%JAMEICA_PROGDIR%\%JAMEICA_JAR%" -f "%JAMEICA_DATADIR%"
+del %LOCKFILE_MY%
+goto ende
+:jameica_in_use
+echo %LOCKFILE_MY%
+set /p JAMEICA_USER=<%LOCKFILE_MY%
+echo **********
+echo * Jameica wird gerade benutzt von
+echo *      %JAMEICA_USER%
+echo **********
+echo * Jameica kann erst gestartet
+echo * werden wenn obiger Benutzer das
+echo * Programm beendet hat.
+echo **********
+pause
+goto ende
+:ende


### PR DESCRIPTION
Bash-Script (je OS), das den Zugriff auf geteilten Ordner (share resource, cloud, z.B. dropbox) verhindert, da jverein nativ keine Multi-User Thread-Sicherheit bietet.

Quelle: http://www.jverein.de/wiki/index.php?title=Multiuser#Multiuser-Setup_per_SVN.2FSubversion