### PR TITLE
Entferne Sun-Interne API (Base64).

### DIFF
--- a/src/de/willuhn/jameica/gui/dialogs/AbstractDialog.java
+++ b/src/de/willuhn/jameica/gui/dialogs/AbstractDialog.java
@@ -87,23 +87,23 @@ public abstract class AbstractDialog<T>
 	 * Positioniert den Dialog an der aktuellen Maus-Position.
 	 */
 	public final static int POSITION_MOUSE = 0;
-	
+
 	/**
 	 * Positioniert den Dialog mittig auf dem Bildschirm.
 	 */
 	public final static int POSITION_CENTER = 1;
-	
+
 	/**
 	 * Positioniert den Dialog auf dem Primaer-Monitor.
 	 */
 	public final static int MONITOR_PRIMARY = 0;
-	
+
 	/**
 	 * Positioniert den Dialog auf dem Monitor, auf dem sich das Jameica-Fenster befindet.
 	 * Das ist der Default-Wert.
 	 */
 	public final static int MONITOR_CURRENT = 1;
-	
+
   protected I18N i18n = Application.getI18n();
 
   private List<Listener> listeners = new ArrayList<Listener>();
@@ -111,7 +111,7 @@ public abstract class AbstractDialog<T>
   private int pos = POSITION_CENTER;
   private int height = SWT.DEFAULT;
   private int width = SWT.DEFAULT;
-  
+
   private boolean resizable = false;
 
   private int monitor = MONITOR_CURRENT;
@@ -129,11 +129,11 @@ public abstract class AbstractDialog<T>
 
 	private String titleText;
   private String panelText;
-	
+
 	private int closeState = SWT.OK;
-	
+
 	private Exception onEscapeException = null;
-	
+
   /**
    * Erzeugt einen neuen Dialog.
    * Er ist nicht groessenaenderbar.
@@ -145,7 +145,7 @@ public abstract class AbstractDialog<T>
 	{
     this(position,true);
 	}
-	
+
   /**
    * Erzeugt einen neuen Dialog.
    * @param position Position des Dialogs.
@@ -158,25 +158,26 @@ public abstract class AbstractDialog<T>
     this.pos       = position;
     this.resizable = resizable;
   }
-  
+
   /**
    * Durch Ueberschreiben dieser Funktion und zurueckliefern von "true" kann man
    * einen Dialog nicht-modal machen, sodass man im Hauptfenster weiterhin Eingaben
    * vornehmen kann, waehrend der Dialog offen ist.
    * Default ist "false".
+   * @return false, wenn der Dialog modal ist (andere Fenster sperrt), andernfalls true.
    */
   protected boolean isModeless()
   {
     return false;
   }
-  
+
   /**
    * Erzeugt die Shell des Dialogs.
    * Kann von abgeleiteten Klassen ueberschrieben werden.
    * Tu das aber bitte nur, wenn du genau weisst, was du tust.
    * @param parent die Parent-Shell.
    * @param flags die Flags.
-   * @return die Shell. 
+   * @return die Shell.
    */
   protected Shell createShell(Shell parent, int flags)
   {
@@ -204,15 +205,15 @@ public abstract class AbstractDialog<T>
         //              der Login-Screen VOR dem Splash-Screen erscheint.
         //              Danach verwenden wir nur noch PRIMARY_MODAL
         Shell rootShell = GUI.getShell();
-        
+
         int modalType = SWT.PRIMARY_MODAL; // Default PRIMARY_MODAL
         if (rootShell.getData("systemshell") == null) // Ausser beim Bootvorgang - da ist das Property nicht gesetzt
           modalType = SWT.APPLICATION_MODAL;
         if (isModeless()) // Es sei denn, es ist explizit ausgeschaltet.
           modalType = SWT.MODELESS;
-        
+
         Logger.debug("modal type: " + (modalType == SWT.APPLICATION_MODAL ? "application" : (modalType == SWT.PRIMARY_MODAL ? "primary" : "modeless")));
-        
+
         int flags = SWT.DIALOG_TRIM | modalType;
         if (resizable)
           flags |= SWT.RESIZE;
@@ -229,10 +230,10 @@ public abstract class AbstractDialog<T>
               // (was dazu fuehren wuerde, dass die open()-Funktion fehlerfrei
               // durchlaeuft - sie aber vermutlich NULL zurueckgibt.
               e.doit = false;
-              
+
               // Wird hier die OperationCancelledException geworfen,
               // wird sie bis zum Aufrufer durchgereicht.
-              
+
               // Wir duerfen die Exception nicht direkt hier werfen. Das bringt
               // SWT/GTK - und damit die ganze JVM - zumindest auf meinem System
               // unter Umstaenden zum Absturz. Scheinbar immer dann, wenn im Dialog
@@ -252,10 +253,10 @@ public abstract class AbstractDialog<T>
           }
         });
 
-        
+
         if (pos == POSITION_MOUSE)
           cursor = display.getCursorLocation();
-        
+
         title = new TitlePart(panelText != null ? panelText : titleText);
         title.paint(shell);
 
@@ -284,7 +285,7 @@ public abstract class AbstractDialog<T>
       }
     });
 	}
-	
+
 	/**
 	 * Fuegt dem Dialog einen Shell-Listener hinzu.
 	 * Der wird u.a. aufgerufen, wenn der User versucht,
@@ -359,7 +360,7 @@ public abstract class AbstractDialog<T>
     // Panel auch aktualisieren
     this.setPanelText(this.panelText);
   }
-  
+
   /**
    * Legt einen abweichenden Text fuer das Panel direkt unter dem Titel fest.
    * Per Default wird dort nochmal der Text des Dialog-Titels angezeigt.
@@ -368,11 +369,11 @@ public abstract class AbstractDialog<T>
   public void setPanelText(String text)
   {
     this.panelText = text;
-    
+
     if (this.title != null)
       this.title.setTitle(this.panelText != null ? this.panelText : this.titleText);
   }
-  
+
   /**
    * Legt fest, auf welchem Monitor der Dialog angezeigt werden soll.
    * @param monitor der Monitor.
@@ -431,7 +432,7 @@ public abstract class AbstractDialog<T>
 	 * werden. Tut sie das, wird der Dialog nicht angezeigt.
    */
   protected abstract void paint(Composite parent) throws Exception;
-	
+
 	/**
 	 * Diese Funktion wird beim Schliessen des Dialogs in open()
 	 * aufgerufen und liefert die ausgewaehlten Daten zurueck.
@@ -441,7 +442,7 @@ public abstract class AbstractDialog<T>
    * @throws Exception
    */
   protected abstract T getData() throws Exception;
-  
+
   /**
    * Kann ueberschrieben werden, um zu beeinflussen, was passieren soll, wenn
    * der User versucht, den Dialog mit Escape zu beenden.
@@ -485,7 +486,7 @@ public abstract class AbstractDialog<T>
 					shell.setText(titleText == null ? "" : titleText);
           if (sideImage != null && !sideImage.isDisposed() && imageLabel != null && !imageLabel.isDisposed())
             imageLabel.setImage(sideImage);
-	
+
 					try
 					{
 						paint(parent);
@@ -503,18 +504,18 @@ public abstract class AbstractDialog<T>
             Logger.debug("using custom dialog size: " + width + "x" + height);
 
             shell.pack();
-            
+
             height = (height == SWT.DEFAULT ? shell.getBounds().height : height);
             width  = (width  == SWT.DEFAULT ? shell.getBounds().width  : width);
-            
+
             shell.setSize(width, height);
-            
+
           }
           else
           {
             shell.pack();
           }
-	
+
           // BUGZILLA 183
           Rectangle displayRect = null;
           if (monitor == AbstractDialog.MONITOR_CURRENT)
@@ -526,16 +527,16 @@ public abstract class AbstractDialog<T>
           Rectangle shellRect = shell.getBounds();
 					int x = displayRect.x + ((displayRect.width - shellRect.width) / 2); // das "displayRect.x" ist wegen Dualhead (die Offset-Position des Monitors)
 					int y = displayRect.y + ((displayRect.height - shellRect.height) / 2);  // das "displayRect.y" ist wegen Dualhead
-					
+
 					Point size = shell.getSize();
-					
+
 					// b) Maus-Position
 					if (pos == POSITION_MOUSE && cursor != null)
 					{
 						x = cursor.x - (size.x / 2);
 						y = cursor.y - (size.y / 2);
 					}
-					
+
 					// BUGZILLA 1087 Out-of-Range-Check (eigentlich nur unter Windows noetig, schaded bei den anderen aber nicht)
           if ((x + size.x) > (displayRect.x + displayRect.width))
           {
@@ -547,9 +548,9 @@ public abstract class AbstractDialog<T>
             // Fenster wuerde ueber den unteren Rand hinausgehen
             y = displayRect.y + displayRect.height - size.y - 4; // 4 Pixel Puffer zum Rand
           }
-					
+
 					shell.setLocation(x, y);
-	
+
 					shell.open();
           shell.forceActive();
 					while (shell != null && !shell.isDisposed() && onEscapeException == null) {
@@ -557,10 +558,10 @@ public abstract class AbstractDialog<T>
 					}
         }
       });
-			
+
 			if (onEscapeException != null)
 			  throw onEscapeException;
-			
+
 			return getData();
 		}
 		catch (OperationCanceledException oce)
@@ -615,13 +616,13 @@ public abstract class AbstractDialog<T>
       Logger.debug("notifying listeners");
 			Event e = new Event();
       e.detail = closeState;
-			
+
       // Wir geben die Daten nur weiter, wenn der Dialog nicht abgebrochen wurde
       // Andernfalls werden Daten vom Aufrufer versehentlich ausgewertet, obwohl
       // er das gar nicht wollte.
       if (e.detail != SWT.CANCEL)
   			e.data = getData();
-			
+
 			for (Listener l:this.listeners)
 			{
 				l.handleEvent(e);

--- a/src/de/willuhn/jameica/gui/input/AbstractInput.java
+++ b/src/de/willuhn/jameica/gui/input/AbstractInput.java
@@ -42,7 +42,7 @@ public abstract class AbstractInput implements Input
   final static I18N i18n = Application.getI18n();
 
   private Map<String,Object> data = new HashMap<String,Object>();
-  
+
   private final static Object PLACEHOLDER = new Object();
 
   private Composite parent = null;
@@ -56,9 +56,9 @@ public abstract class AbstractInput implements Input
 
   private String validChars = null;
   private String invalidChars = null;
-  
+
   private boolean mandatory = false;
-  
+
   private Object oldValue = PLACEHOLDER;
 
   /**
@@ -69,7 +69,7 @@ public abstract class AbstractInput implements Input
   {
     return this.parent;
   }
-  
+
   /**
    * Liefert die Stylebits (GridData-Settings), welche zum Erstellen des Widgets
    * verwendet werden.
@@ -129,7 +129,7 @@ public abstract class AbstractInput implements Input
 
     control = getControl();
     applyVerifier(control);
-    
+
     if (control.getLayoutData() == null)
     {
       final GridData inputGrid = new GridData(getStyleBits());
@@ -156,7 +156,7 @@ public abstract class AbstractInput implements Input
 			control.addListener(SWT.FocusIn,l);
 			control.addListener(SWT.FocusOut,l);
     }
-    
+
     // Es kann sein, dass das Control ein Composite ist (z.Bsp. bei DialogInput)
     // Wenn es also aus mehren Elementen besteht, dann muessen wir
 		// den Listener an alle haengen.
@@ -176,12 +176,12 @@ public abstract class AbstractInput implements Input
         applyVerifier(children[j]);
 			}
 		}
-    
+
     // Einmal manuell starten, damit es vor dem ersten
     // verify event ausgeloest wird
     update();
   }
-  
+
   /**
    * Fuegt die Verifier dem Control hinzu.
    * @param control
@@ -190,9 +190,9 @@ public abstract class AbstractInput implements Input
   {
     if (control == null || !(control instanceof Text))
       return;
-    
+
     Listener updateCheck = new Listener() {
-    
+
       public void handleEvent(Event event)
       {
         try
@@ -224,7 +224,7 @@ public abstract class AbstractInput implements Input
         }
       });
     }
-    
+
     if ((validChars != null && validChars.length() > 0))
     {
       control.addListener(SWT.Verify, new Listener()
@@ -269,7 +269,7 @@ public abstract class AbstractInput implements Input
    * Werden beide Funktionen <code>setValidChars</code> <b>und</b>
    * <code>setInvalidChars</code> benutzt, kann nur noch die verbleibende
    * Restmenge eingegeben werden. Das sind die Zeichen, die in validChars
-   * angegeben und in invalidChars nicht enthalten sind. 
+   * angegeben und in invalidChars nicht enthalten sind.
    * @param chars
    */
   public void setValidChars(String chars)
@@ -297,12 +297,13 @@ public abstract class AbstractInput implements Input
   }
 
   private boolean inUpdate = false;
-  
+
   /**
    * Wird immer dann aufgerufen, wenn eines der Controls des
    * Eingabe-Feldes aktualisiert wird. Hier kann dann z.Bsp.
    * geprueft werden, ob der Inhalt des Feldes korrekt ist
    * und ggf. die Hintergrund-Farbe angepasst werden.
+   * @throws OperationCanceledException der Vorgang wurde abgebrochen.
    */
   protected void update() throws OperationCanceledException
   {
@@ -318,7 +319,7 @@ public abstract class AbstractInput implements Input
 
       if (!isEnabled())
         return;
-      
+
       Object value = getValue();
 
       if (isMandatory() && (value == null || "".equals(value.toString())))
@@ -333,7 +334,7 @@ public abstract class AbstractInput implements Input
       inUpdate = false;
     }
   }
-  
+
   /**
    * @see de.willuhn.jameica.gui.input.Input#setMandatory(boolean)
    */
@@ -379,7 +380,7 @@ public abstract class AbstractInput implements Input
       Object o = this.getData("jameica.label");
       if (o == null || !(o instanceof Label))
         return;
-      
+
       Label label = (Label) o;
       if (label.isDisposed())
         return;
@@ -423,8 +424,8 @@ public abstract class AbstractInput implements Input
   {
     return this.data.get(key);
   }
-  
-  
+
+
 }
 
 /*********************************************************************

--- a/src/de/willuhn/jameica/security/crypto/AbstractPasswordBasedEngine.java
+++ b/src/de/willuhn/jameica/security/crypto/AbstractPasswordBasedEngine.java
@@ -7,6 +7,13 @@
 
 package de.willuhn.jameica.security.crypto;
 
+import de.willuhn.io.IOUtil;
+import de.willuhn.jameica.security.Wallet;
+import de.willuhn.logging.Logger;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.bouncycastle.util.encoders.Base64;
+
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.Key;
@@ -16,13 +23,6 @@ import java.security.spec.AlgorithmParameterSpec;
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
 import javax.crypto.CipherOutputStream;
-
-import org.apache.commons.lang.RandomStringUtils;
-
-import de.willuhn.io.IOUtil;
-import de.willuhn.jameica.security.Wallet;
-import de.willuhn.logging.Logger;
-import de.willuhn.util.Base64;
 
 /**
  * Abstrakte Basis-Implementierung einer Passwort-basierten Crypto-Engine.
@@ -34,11 +34,12 @@ public abstract class AbstractPasswordBasedEngine implements Engine
   /**
    * @see de.willuhn.jameica.security.crypto.Engine#encrypt(java.io.InputStream, java.io.OutputStream)
    */
+  @Override
   public void encrypt(InputStream is, OutputStream os) throws Exception
   {
     OutputStream cos = this.encrypt(os);
     IOUtil.copy(is,cos);
-    
+
     // Wir muessen den CipherOutputStream leider selbst schliessen, damit das doFinal intern gemacht wird
     // Das schliesst zwar auch bereits "os" - aber das laesst sich nicht vermeiden.
     cos.close();
@@ -47,15 +48,17 @@ public abstract class AbstractPasswordBasedEngine implements Engine
   /**
    * @see de.willuhn.jameica.security.crypto.Engine#decrypt(java.io.InputStream, java.io.OutputStream)
    */
+  @Override
   public void decrypt(InputStream is, OutputStream os) throws Exception
   {
     InputStream cis = this.decrypt(is);
     IOUtil.copy(cis, os);
   }
-  
+
   /**
    * @see de.willuhn.jameica.security.crypto.Engine#encrypt(java.io.OutputStream)
    */
+  @Override
   public OutputStream encrypt(OutputStream os) throws Exception
   {
     Logger.debug("encrypting data using " + getAlgorithm());
@@ -66,6 +69,7 @@ public abstract class AbstractPasswordBasedEngine implements Engine
   /**
    * @see de.willuhn.jameica.security.crypto.Engine#decrypt(java.io.InputStream)
    */
+  @Override
   public InputStream decrypt(InputStream is) throws Exception
   {
     Logger.debug("decrypting data using " + getAlgorithm());
@@ -102,7 +106,7 @@ public abstract class AbstractPasswordBasedEngine implements Engine
       this.wallet = new Wallet(this.getClass(), new RSAEngine());
     return this.wallet;
   }
-  
+
   /**
    * Liefert das Salt fuer die Verschluesselung.
    * @param len Laenge in Bytes.
@@ -113,19 +117,18 @@ public abstract class AbstractPasswordBasedEngine implements Engine
   {
     if (len < 1)
       throw new Exception("invalid salt length: " + len);
-    
+
     // Checken, ob wir schon eins haben.
     Wallet wallet = this.getWallet();
-    
+
     // Migration. Wir hatten das anfangs falsch ohne Laenge gespeichert
     String s = (String) wallet.get("salt"); // wir speichern nicht direkt das Array, weil das das Wallet aufblaest
     if (s == null)
       s = (String) wallet.get("salt." + len); // Das ist jetzt der neue Platz
-    if (s != null)
+    if (s != null) {
       return Base64.decode(s);
-    
-    
-      
+    }
+
     // Neu erstellen
     Logger.debug("creating new salt");
     byte[] salt = new byte[len];
@@ -135,7 +138,7 @@ public abstract class AbstractPasswordBasedEngine implements Engine
     wallet.set("salt." + len,Base64.encode(salt));
     return salt;
   }
-  
+
   /**
    * Liefert das Passwort fuer die Verschluesselung.
    * @param len Laenge in Zeichen.
@@ -149,34 +152,34 @@ public abstract class AbstractPasswordBasedEngine implements Engine
 
     // Checken, ob wir schon eins haben.
     Wallet wallet = this.getWallet();
-    
+
     // Migration. Wir hatten das anfangs falsch ohne Laenge gespeichert
     String s = (String) wallet.get("password"); // wir speichern nicht direkt das Array, weil das das Wallet aufblaest
     if (s == null)
       s = (String) wallet.get("password." + len); // Das ist jetzt der neue Platz
     if (s != null)
       return s.toCharArray();
-    
+
     // Neu erstellen
     s = RandomStringUtils.randomAscii(len);
     Logger.debug("created random password, length: " + s.length());
     wallet.set("password." + len,s);
     return s.toCharArray();
   }
-  
+
   /**
    * Liefert die Parameter des Algorithmus.
    * @return die Parameter des Algorithmus.
    * @throws Exception
    */
   abstract AlgorithmParameterSpec getParameterSpec() throws Exception;
-  
+
   /**
    * Liefert den Namen des Algorithmus.
    * @return der Namen des Algorithmus.
    */
   abstract String getAlgorithm();
-  
+
   /**
    * Liefert den Schluessel.
    * @return der Schluessel.

--- a/src/de/willuhn/jameica/system/Config.java
+++ b/src/de/willuhn/jameica/system/Config.java
@@ -12,6 +12,12 @@
  **********************************************************************/
 package de.willuhn.jameica.system;
 
+import de.willuhn.logging.Level;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+import org.apache.commons.lang.StringUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.BindException;
@@ -20,14 +26,9 @@ import java.util.ArrayList;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
-import org.apache.commons.lang.StringUtils;
-
-import de.willuhn.logging.Level;
-import de.willuhn.logging.Logger;
-import de.willuhn.util.ApplicationException;
-
 /**
- * Liest die System-Konfiguration aus config.xml. 
+ * Liest die System-Konfiguration aus config.xml.
+ *
  * @author willuhn
  */
 public final class Config
@@ -37,7 +38,7 @@ public final class Config
    */
   public final static int RMI_DEFAULT_PORT = 4840;
 
-	private File workDir   	     = null;
+  private File workDir   	     = null;
   private File configDir       = null;
 
   private Locale locale        = null;
@@ -51,6 +52,9 @@ public final class Config
 
   /**
    * ct.
+   *
+   * @throws Exception
+   *           on any error.
    */
   protected Config() throws Exception
   {
@@ -86,7 +90,7 @@ public final class Config
         Logger.error("unable to determine workdir, fallback to default workdir " + this.workDir,e);
         throw e;
       }
-      
+
       // Migration 2012-10-05 (2.2 -> 2.4)
       // Deploy-Dir loeschen - wird inzwischen nicht mehr gebraucht
       File deploy = new File(this.workDir,"deploy");
@@ -113,16 +117,18 @@ public final class Config
     return settings.getInt("jameica.system.rmi.serverport",RMI_DEFAULT_PORT);
   }
 
-	/**
-	 * Speichert den zu verwendenden TCP-Port fuer die lokale RMI-Registry.
+  /**
+   * Speichert den zu verwendenden TCP-Port fuer die lokale RMI-Registry.
    * @param port
    * @throws ApplicationException Wird geworfen, wenn die Port-Angabe ungueltig (kleiner 1 oder groesser 65535) ist
    * oder der Port bereits belegt.
    */
   public void setRmiPort(int port) throws ApplicationException
-	{
+  {
     if (port < 1 || port > 65535)
-      throw new ApplicationException(Application.getI18n().tr("TCP-Portnummer für Netzwerkbetrieb ausserhalb des gültigen Bereichs von {0} bis {1}", new String[]{""+1,""+65535}));
+      throw new ApplicationException(
+          Application.getI18n().tr("TCP-Portnummer für Netzwerkbetrieb ausserhalb des gültigen Bereichs von {0} bis {1}",
+              new String[] { "" + 1, "" + 65535 }));
 
     ServerSocket s = null;
     try
@@ -155,16 +161,16 @@ public final class Config
       }
     }
     settings.setAttribute("jameica.system.rmi.serverport",port);
-	}
+  }
 
-	/**
-	 * Prueft, ob die RMI-Verbindungen SSL-verschluesselt werden sollen.
+  /**
+   * Prueft, ob die RMI-Verbindungen SSL-verschluesselt werden sollen.
    * @return true, wenn die Verwendung von SSL aktiv ist.
    */
   public boolean getRmiSSL()
-	{
-		return settings.getBoolean("jameica.system.rmi.enablessl",true);
-	}
+  {
+    return settings.getBoolean("jameica.system.rmi.enablessl",true);
+  }
 
   /**
    * Prueft, ob bei SSL-verschluesselten RMI-Verbindungen Client-Authentifizierung verwendet werden soll.
@@ -206,7 +212,7 @@ public final class Config
       host = null;
     settings.setAttribute("jameica.system.proxy.host",host);
   }
-  
+
   /**
    * Speichert die TCP-Portnummer des Proxys.
    * @param port Port-Nummer.
@@ -222,7 +228,8 @@ public final class Config
     }
 
     if (port < 1 || port > 65535)
-      throw new ApplicationException(Application.getI18n().tr("TCP-Portnummer für Proxy ausserhalb des gültigen Bereichs von {0} bis {1}", new String[]{""+1,""+65535}));
+      throw new ApplicationException(Application.getI18n().tr(
+          "TCP-Portnummer für Proxy ausserhalb des gültigen Bereichs von {0} bis {1}", new String[] { "" + 1, "" + 65535 }));
 
     settings.setAttribute("jameica.system.proxy.port",port);
   }
@@ -256,7 +263,7 @@ public final class Config
       host = null;
     settings.setAttribute("jameica.system.proxy.https.host",host);
   }
-  
+
   /**
    * Speichert die TCP-Portnummer des HTTPS-Proxys.
    * @param port Port-Nummer.
@@ -272,11 +279,13 @@ public final class Config
     }
 
     if (port < 1 || port > 65535)
-      throw new ApplicationException(Application.getI18n().tr("TCP-Portnummer für HTTPS-Proxy ausserhalb des gültigen Bereichs von {0} bis {1}", new String[]{""+1,""+65535}));
+      throw new ApplicationException(
+          Application.getI18n().tr("TCP-Portnummer für HTTPS-Proxy ausserhalb des gültigen Bereichs von {0} bis {1}",
+              new String[] { "" + 1, "" + 65535 }));
 
     settings.setAttribute("jameica.system.proxy.https.port",port);
   }
-  
+
   /**
    * Prueft, ob die Proxy-Einstellungen des Systems verwendet werden sollen.
    * @return true, wenn die Default-Systemeinstellungen verwendet werden sollen.
@@ -285,16 +294,18 @@ public final class Config
   {
     return settings.getBoolean("jameica.system.proxy.usesystem",false);
   }
-  
+
   /**
-   * Legt fest, ob die System-Einstellungen fuer den Proxy verwendet werden sollen. 
-   * @param b true, wenn die System-Einstellungen des Betriebssystems verwendet werden sollen.
+   * Legt fest, ob die System-Einstellungen fuer den Proxy verwendet werden sollen.
+   *
+   * @param b
+   *          true, wenn die System-Einstellungen des Betriebssystems verwendet werden sollen.
    */
   public void setUseSystemProxy(boolean b)
   {
     settings.setAttribute("jameica.system.proxy.usesystem",b);
   }
-  
+
   /**
    * Liefert true, wenn den Aussteller-Zertifikaten der Java-Installation vertraut werden soll.
    * @return true, wenn den Aussteller-Zertifikaten der Java-Installation vertraut werden soll.
@@ -335,13 +346,13 @@ public final class Config
   }
 
   /**
-	 * Aktiviert oder deaktiviert die Verwendung von SSL fuer die RMI-Verbindungen.
+   * Aktiviert oder deaktiviert die Verwendung von SSL fuer die RMI-Verbindungen.
    * @param b
    */
   public void setRmiSSL(boolean b)
-	{
-		settings.setAttribute("jameica.system.rmi.enablessl",b);
-	}
+  {
+    settings.setAttribute("jameica.system.rmi.enablessl",b);
+  }
 
   /**
    * Liefert das konfigurierte Locale (Sprach-Auswahl).
@@ -353,12 +364,12 @@ public final class Config
       return locale;
 
     try {
-      
+
       // Wenn ein Locale konfiguriert ist, nehmen wir das - insofern ex existiert
       Locale l = findLocale(settings.getString("jameica.system.locale",null));
       if (l == null)
         l = Locale.getDefault();
-      
+
       try
       {
         Logger.info("checking resource bundle for language");
@@ -370,7 +381,7 @@ public final class Config
         l = Locale.GERMANY;
         Logger.warn("fallback to system locale " + l);
       }
-      
+
       this.locale = l;
       Logger.info("active language: " + this.locale);
       Locale.setDefault(this.locale);
@@ -382,7 +393,7 @@ public final class Config
     }
     return Locale.getDefault();
   }
-  
+
   /**
    * Versucht das Locale zum angegebenen Text zu ermitteln.
    * @param s der Text.
@@ -391,7 +402,7 @@ public final class Config
   private static Locale findLocale(String s)
   {
     s = StringUtils.trimToNull(s);
-    
+
     if (s == null)
       return null;
 
@@ -414,14 +425,14 @@ public final class Config
     return new Locale(s);
   }
 
-	/**
-	 * Speichert das Locale (Sprach-Auswahl).
+  /**
+   * Speichert das Locale (Sprach-Auswahl).
    * @param l das zu verwendende Locale.
    */
   public void setLocale(Locale l)
-	{
-		if (l == null)
-			return;
+  {
+    if (l == null)
+      return;
     this.locale = l;
     String lang    = this.locale.getLanguage();
     String country = this.locale.getCountry();
@@ -429,7 +440,7 @@ public final class Config
       settings.setAttribute("jameica.system.locale",lang + "_" + country);
     else
       settings.setAttribute("jameica.system.locale",lang);
-	}
+  }
 
   /**
    * Liefert die in ~/.jameica/cfg/de.willuhn.jameica.system.Config.properties definierten
@@ -447,9 +458,9 @@ public final class Config
     // hier raus, falls sie auftauchen
     File sysPluginDir = getSystemPluginDir();
     File usrPluginDir = getUserPluginDir();
-    
+
     boolean found = false;
-    
+
     ArrayList<File> l = new ArrayList<File>();
 
     String[] s = settings.getList("jameica.plugin.dir",null);
@@ -468,25 +479,25 @@ public final class Config
         {
           Logger.warn("unable to convert " + f.getAbsolutePath() + " into canonical path");
         }
-        
+
         if (f.equals(sysPluginDir) || f.equals(usrPluginDir))
         {
           Logger.info("skipping system/user plugin dir in jameica.plugin.dir[" + i + "]");
           found = true;
           continue;
         }
-        
+
         if (!f.canRead() || !f.isDirectory())
         {
           Logger.warn(f.getAbsolutePath() + " is no valid plugin dir, skipping");
           continue;
         }
-        
+
         Logger.info("adding plugin dir " + f.getAbsolutePath());
         l.add(f);
       }
     }
-    
+
     // Migration: Wir schreiben die Liste der Plugin-Verzeichnisse neu,
     // damit System- und User-Verzeichnis rausfliegen.
     if (found)
@@ -498,11 +509,11 @@ public final class Config
       }
       settings.setAttribute("jameica.plugin.dir",newList);
     }
-    
+
     this.pluginDirs = l.toArray(new File[l.size()]);
     return this.pluginDirs;
   }
-  
+
   /**
    * Liefert das System-Plugin-Verzeichnis.
    * Das ist jenes, welches sich im Jameica-Verzeichnis befindet.
@@ -581,7 +592,7 @@ public final class Config
     }
     return this.updateDir;
   }
-  
+
   /**
    * Liefert Pfad und Dateiname des Log-Files.
    * @return Logfile.
@@ -590,7 +601,7 @@ public final class Config
   {
     return getWorkDir() + File.separator + "jameica.log";
   }
-  
+
   /**
    * Liefert die Dateigroesse nach der die Log-Datei rotiert und gezippt wird.
    * @return die Dateigroesse des Logs in Bytes.
@@ -649,16 +660,16 @@ public final class Config
     return settings.getString("jameica.system.log.level",Level.DEFAULT.getName());
   }
 
-	/**
-	 * Legt den Log-Level fest.
+  /**
+   * Legt den Log-Level fest.
    * @param name Name des Log-Levels.
    */
   public void setLoglevel(String name)
-	{
+  {
     settings.setAttribute("jameica.system.log.level",name);
     // Aenderungen sofort uebernehmen
     Logger.setLevel(Level.findByName(name));
-	}
+  }
 
   /**
    * Liefert den Pfad zum Config-Verzeichnis.
@@ -678,21 +689,21 @@ public final class Config
     return configDir.getAbsolutePath();
   }
 
-	/**
-	 * Liefert das Work-Verzeichnis von Jameica.
+  /**
+   * Liefert das Work-Verzeichnis von Jameica.
    * @return das Work-Verzeichnis von Jameica.
    */
   public String getWorkDir()
-	{
-		try {
-			return workDir.getCanonicalPath();
-		}
-		catch (IOException e)
-		{
-			return workDir.getAbsolutePath();
-		}
-	}
-  
+  {
+    try {
+      return workDir.getCanonicalPath();
+    }
+    catch (IOException e)
+    {
+      return workDir.getAbsolutePath();
+    }
+  }
+
   /**
    * Liefert das Backup-Verzeichnis.
    * @return Backup-Verzeichnis.
@@ -708,11 +719,11 @@ public final class Config
     String dir = settings.getString("jameica.system.backup.dir",null);
     if (dir == null)
       return defaultDir;
-    
+
     File f = new File(dir);
     if (f.exists() && f.isDirectory() && f.canWrite())
       return f.getAbsolutePath();
-    
+
     Logger.warn("invalid backup dir " + dir +", resetting to default: " + defaultDir);
     setBackupDir(null);
     return defaultDir;
@@ -734,7 +745,7 @@ public final class Config
       settings.setAttribute("jameica.system.backup.dir",(String)null);
       return;
     }
-    
+
     // Angegebenes Verzeichnis ist das Work-Dir.
     // Also resetten
     File f = new File(dir);
@@ -756,16 +767,16 @@ public final class Config
         return;
       }
     }
-    
+
     if (!f.isDirectory() || !f.exists())
       throw new ApplicationException(Application.getI18n().tr("Bitte geben Sie ein gültiges Verzeichnis an"));
-    
+
     if (!f.canWrite())
       throw new ApplicationException(Application.getI18n().tr("Sie besitzen keine Schreibrechte in diesem Verzeichnis"));
-    
+
     settings.setAttribute("jameica.system.backup.dir",f.getAbsolutePath());
   }
-  
+
   /**
    * Liefert die Anzahl zu erstellender Backups.
    * Default-Wert: 10.
@@ -781,7 +792,7 @@ public final class Config
     }
     return count;
   }
-  
+
   /**
    * Speichert die Anzahl zu erstellender Backups.
    * @param count Anzahl der Backups.
@@ -790,7 +801,7 @@ public final class Config
   {
     settings.setAttribute("jameica.system.backup.count",count < 1 ? 10 : count);
   }
-  
+
   /**
    * Prueft, ob ueberhaupt Backups erstellt werden sollen.
    * Default: true.
@@ -809,7 +820,7 @@ public final class Config
   {
     settings.setAttribute("jameica.system.backup.enabled",enabled);
   }
-  
+
   /**
    * Liefert das Verzeichnis, in dem Strings gespeichert werden sollen,
    * zu denen keine Uebersetzungen existieren.


### PR DESCRIPTION
Hintergrund: Base64 aus den Utils verwendet eine Sun-Interne API.
Damit wäre Hibiscus auf OpenJDK oder einem IBM-JDK oder anderen nicht
lauffähig. Es gibt aber genug andere Abhängigkeiten, die einen
gleichwertigen De- und Encoder mitbringen.
In diesem Fall Bouncy Castle, weil die Abhängigkeit in jedem Fall
drinbleiben muss -- Apache Commons könnte man theoretisch auch irgenwann
durch Guava ablösen, dafür habe ich aber keine Intentionen. ;-)