### PR TITLE
fix auto snapout for imports

### DIFF
--- a/src/de/willuhn/jameica/gui/internal/parts/BackgroundTaskMonitor.java
+++ b/src/de/willuhn/jameica/gui/internal/parts/BackgroundTaskMonitor.java
@@ -259,8 +259,6 @@ public class BackgroundTaskMonitor extends ProgressBar
    */
   public void setStatus(int status)
   {
-    check();
-    
     // Wenn wir in einem finalen Zustand sind, kann der Cancel-Button nicht mehr gedrueckt werden
     boolean finalState = (status == ProgressMonitor.STATUS_CANCEL) ||
                          (status == ProgressMonitor.STATUS_DONE) ||
@@ -269,6 +267,7 @@ public class BackgroundTaskMonitor extends ProgressBar
       this.getCancelButton().setEnabled(false);
     
     super.setStatus(status);
+    check();
   }
 
   /**


### PR DESCRIPTION
Aktuell funktioniert das Auto-Snapout bei Importen nicht vollständig. Hintergrund ist, dass nicht alle Importer selbst den Monitor-Status setzen. Das macht zur Zeit der ImportDialog - allerdings als allerletztes. BackgroundTaskMonitor#setStatus führt check vor dem Setzen des Status aus, so dass das Ping-Event nicht den neuen Status verwendet, sondern den alten. Als Folge kommt dieser alte Status beim Auto-Snapout-Listener an.

Die vorgeschlagene Änderung verlagert den check-Aufruf hinter das eigentliche Status-Setzen. Eine alternative Lösung wäre, im Import-Dialog das Status-Setzen vor das setPercentComplete zu verlagern (Zeile 178).

P.S.: Tatsächlich könnte man sich aufgrund des setPercentComplete im Dialog die entsprechenden Aufrufe in den Einzelimportern sparen.