### PR TITLE
improved comma handling in decimal input

### DIFF
--- a/src/de/willuhn/jameica/gui/input/DecimalInput.java
+++ b/src/de/willuhn/jameica/gui/input/DecimalInput.java
@@ -123,11 +123,8 @@ public class DecimalInput extends TextInput
             // Jepp, da ist schon ein Komma
             e.doit = false;
             boolean newInputIsCommaOnly=e.text.length()==1;
-            if(newInputIsCommaOnly && e.start<existingCommaIndex){
-              //Selektiere den Text zwischen aktueller Position und hinter bereits existierendem Komma.
-              //Dieser wird dann vom neuen Komma ersetzt, neue Cursorposition ist hinter dem Komma.
-              text.setSelection(e.start, existingCommaIndex+1);
-              e.doit=true;
+            if(newInputIsCommaOnly && text.getSelectionText().length()==0){
+              text.setSelection(existingCommaIndex+1);
             }
             return;
           }

--- a/src/de/willuhn/jameica/gui/input/DecimalInput.java
+++ b/src/de/willuhn/jameica/gui/input/DecimalInput.java
@@ -117,10 +117,18 @@ public class DecimalInput extends TextInput
           }
           
           // Jetzt checken wir noch, ob schon ein Komma eingegeben wurde
-          if (chars[i] == komma && (text.getText()+"").indexOf(komma) != -1 && e.text.indexOf(komma) != -1)
+          int existingCommaIndex=(text.getText()+"").indexOf(komma);
+          if (chars[i] == komma && existingCommaIndex != -1)
           {
             // Jepp, da ist schon ein Komma
             e.doit = false;
+            boolean newInputIsCommaOnly=e.text.length()==1;
+            if(newInputIsCommaOnly && e.start<existingCommaIndex){
+              //Selektiere den Text zwischen aktueller Position und hinter bereits existierendem Komma.
+              //Dieser wird dann vom neuen Komma ersetzt, neue Cursorposition ist hinter dem Komma.
+              text.setSelection(e.start, existingCommaIndex+1);
+              e.doit=true;
+            }
             return;
           }
 


### PR DESCRIPTION
Aktuell wird bei der Eingabe eines Betrags ein Komma ignoriert, wenn bereits eins existiert. Um den Cent-Betrag einzugeben, muss man hinnavigieren. Bei der Eingabe manueller Buchungen (0,00 vorausgefüllt) oder Korrektur von Beträgen fände ich folgendes Verhalten schöner: ich gebe vorn anfangend die Zahl ein und wenn ich ein Komma eintippe, stehe ich hinter dem Komma.

Im aktuellen Pullrequest wird dabei der Text hinter der aktuellen Position bis zum Komma gelöscht. Intention ist, dass die bislang eingegebene Zahl der korrekte Eurobetrag ist (und ich nicht nur eine Ziffer des Eurobetrags korrigiert habe und nun Cents korrigieren will).

Ein reines Ändern der Cursorposition ohne Abschneiden eines Betrags ließe sich alternativ durch
`text.setSelection(existingCommaIndex+1);` erreichen.

Die Eingabe eines Komma hinter einem bereits existierenden wird ignoriert. Hier wäre das Springen hinter dieses Komma eine Möglichkeit.

Die dritte Bedinung des if-Blocks ist meiner Ansicht nach redundant, da das Array `chars` bereits `e.text` enthält und damit die erste Bedingung nur wahr wird, wenn ein Komma enthalten ist.