### PR TITLE
Decimal Input: selectAll on focusIn, formatting only on focusOut

### DIFF
--- a/src/de/willuhn/jameica/gui/input/DecimalInput.java
+++ b/src/de/willuhn/jameica/gui/input/DecimalInput.java
@@ -70,11 +70,17 @@ public class DecimalInput extends TextInput
         this.format.setParseBigDecimal(true);
     }
 
-    // BUGZILLA 1014 Der Code war vorher 1:1 in Hibiscus auch drin. Ich hoffe, der macht hier jetzt keine Probleme.
+    // BUGZILLA 1014 Der Code war vorher ähnlich in Hibiscus auch drin. Ich hoffe, der macht hier jetzt keine Probleme.
+    // Anpassung: setValue für erzwungene Formatierung nur beim Verlassen
+    // Neu: Selektion bei Focus
     this.addListener(new Listener() {
       public void handleEvent(Event event)
       {
-        setValue(getValue()); // forciert das Formatieren des Betrages
+         if(event.type==SWT.FocusIn) {
+          text.selectAll();
+        }else if(event.type==SWT.FocusOut){
+          setValue(getValue()); // forciert das Formatieren des Betrages
+        }
       }
     });
   }


### PR DESCRIPTION
Unter meinem Windows 7, wird beim Betreten des DecimalInput der Text bislang nicht selektiert, wie es laut Aussage im Pull Request #20 unter Linux der Fall ist.
Die aktuelle Änderung führt die Formatierung ausschließlich beim Verlassen des Feldes aus (wie es in Bugzilla 1014 als gewünschtes Verhalten beschrieben steht) und selektiert den Inhalt bei FocusIn explizit - nun auch bei mir.

Die Selektion erfolgt allerdings nur bei Tabulator-Navigation, also insb. nicht wenn man mit der Maus das Feld anklickt (dann wird die initiale Selektion durch ein weiteres noch nicht näher untersuchtes Event wieder entfernt; wahrscheinlich das Setzen des Cursors an die entsprechende Position der Maus). Ist das unter Linux auch so, oder ist dort in jedem Fall der gesamte Feldinhalt markiert?