### PR TITLE
Remove module java.se.ee

### DIFF
--- a/build/jameica-macos.sh
+++ b/build/jameica-macos.sh
@@ -40,5 +40,4 @@ fi
 BASEDIR=$(dirname "$0")
 cd "${BASEDIR}"
 
-export JDK_JAVA_OPTIONS='--add-modules=java.se.ee'
 exec "${JAVACMD}" -Xdock:name="Jameica" -Xmx512m -Xss64m -XstartOnFirstThread -jar "${BASEDIR}/jameica-macos.jar" -o "$@"  >/dev/null

--- a/build/jameica-macos64.sh
+++ b/build/jameica-macos64.sh
@@ -40,5 +40,4 @@ fi
 BASEDIR=$(dirname "$0")
 cd "${BASEDIR}"
 
-export JDK_JAVA_OPTIONS='--add-modules=java.se.ee'
 exec "${JAVACMD}" -Xdock:name="Jameica" -Xmx512m -Xss64m -XstartOnFirstThread -jar "${BASEDIR}/jameica-macos64.jar" -o "$@"  >/dev/null

--- a/build/jameica-openbsd.sh
+++ b/build/jameica-openbsd.sh
@@ -7,5 +7,4 @@ link=$(readlink -f "$0")
 dir=$(dirname "$link")
 cd "$dir" 
 
-export JDK_JAVA_OPTIONS='--add-modules=java.se.ee'
 java -Xmx512m -Xss64m -jar jameica-openbsd.jar $@

--- a/build/jameica.sh
+++ b/build/jameica.sh
@@ -18,5 +18,4 @@ else
 	archsuffix=""
 fi
 
-export JDK_JAVA_OPTIONS='--add-modules=java.se.ee'
 LIBOVERLAY_SCROLLBAR=0 GDK_NATIVE_WINDOWS=1 SWT_GTK3=0 exec java -Djava.net.preferIPv4Stack=true -Xmx512m -Xss64m $_JCONSOLE -jar jameica-linux${archsuffix}.jar $@

--- a/build/jameicaserver.sh
+++ b/build/jameicaserver.sh
@@ -11,5 +11,4 @@ cd "$dir"
 
 # https://www.willuhn.de/bugzilla/show_bug.cgi?id=798
 
-export JDK_JAVA_OPTIONS='--add-modules=java.se.ee'
 java -Djava.net.preferIPv4Stack=true -Xmx512m $_JCONSOLE -jar jameica-linux.jar -d $@

--- a/build/launch4j-win32.xml
+++ b/build/launch4j-win32.xml
@@ -14,7 +14,6 @@
   <restartOnCrash>false</restartOnCrash>
   <manifest></manifest>
   <icon>/work/willuhn/git/hibiscus/icons/hibiscus.ico</icon>
-  <var>JDK_JAVA_OPTIONS=&apos;--add-modules=java.se.ee&apos;</var>
   <jre>
     <path></path>
     <bundledJre64Bit>false</bundledJre64Bit>

--- a/build/launch4j-win64.xml
+++ b/build/launch4j-win64.xml
@@ -14,7 +14,6 @@
   <restartOnCrash>false</restartOnCrash>
   <manifest></manifest>
   <icon>/work/willuhn/git/hibiscus/icons/hibiscus.ico</icon>
-  <var>JDK_JAVA_OPTIONS=&apos;--add-modules=java.se.ee&apos;</var>
   <jre>
     <path></path>
     <bundledJre64Bit>false</bundledJre64Bit>

--- a/build/rcjameica
+++ b/build/rcjameica
@@ -19,8 +19,6 @@ link=${base#*[SK][0-9][0-9]}
 JAVA=`which java`
 BASEDIR=`dirname $0`
 
-export JDK_JAVA_OPTIONS='--add-modules=java.se.ee'
-
 ### Please do not edit anything below this line! ########################
 #                                                                       #
 


### PR DESCRIPTION
Meine Distribution (openSUSE Tumbleweed) setzt schon jetzt auf Java11 auf. In Java11 wird jedoch das Modul `java.se.ee` nicht mehr unterstützt. Wenn die Option aus den Shell-Skripten entfernt wird ist es wieder lauffähig. Ich wollte eigentlich einen Bug-Report über BugZilla aufmachen (man kann sich nur nicht registrieren), daher dieser eher beispielhafte Pull Request.