### PR TITLE
`List` -> `List<Result>`

### DIFF
--- a/src/de/willuhn/jameica/bookmark/BookmarkSearchProvider.java
+++ b/src/de/willuhn/jameica/bookmark/BookmarkSearchProvider.java
@@ -44,7 +44,7 @@ public class BookmarkSearchProvider implements SearchProvider
   /**
    * @see de.willuhn.jameica.search.SearchProvider#search(java.lang.String)
    */
-  public List search(String search) throws RemoteException, ApplicationException
+  public List<Result> search(String search) throws RemoteException, ApplicationException
   {
     if (search == null || search.length() == 0)
       return null;

--- a/src/de/willuhn/jameica/search/SearchProvider.java
+++ b/src/de/willuhn/jameica/search/SearchProvider.java
@@ -39,7 +39,7 @@ public interface SearchProvider
    * @throws RemoteException
    * @throws ApplicationException
    */
-  public List search(String search) throws RemoteException, ApplicationException;
+  public List<Result> search(String search) throws RemoteException, ApplicationException;
 }
 
 


### PR DESCRIPTION
Wie im JavaDoc des Interfaces `SearchProvider` beschrieben, darf der Inhalt der Liste ausschließlich aus Objekten vom Typ `Result` bestehen.

Das Interface wird auch von mehreren Klassen in [Hibiscus](https://github.com/willuhn/hibiscus) verwendet, weshalb es dort ebenfalls einen entsprechenden Commit gibt.