### PR TITLE
Fix deprecated warnings of constructors

### DIFF
--- a/src/de/willuhn/jameica/backup/BackupFile.java
+++ b/src/de/willuhn/jameica/backup/BackupFile.java
@@ -143,7 +143,7 @@ public class BackupFile implements GenericObject
     if ("created".equals(name))
       return new Date(this.file.lastModified());
     if ("size".equals(name))
-      return new Long(this.file.length());
+      return Long.valueOf(this.file.length());
     return BeanUtil.get(this.file,name);
   }
 

--- a/src/de/willuhn/jameica/gui/boxes/AbstractBox.java
+++ b/src/de/willuhn/jameica/gui/boxes/AbstractBox.java
@@ -48,7 +48,7 @@ public abstract class AbstractBox implements Box
   public int getIndex()
   {
     if (this.index == null)
-      this.index = new Integer(settings.getInt(this.getClass().getName() + ".index",getDefaultIndex()));
+      this.index = Integer.valueOf(settings.getInt(this.getClass().getName() + ".index",getDefaultIndex()));
     return this.index.intValue();
   }
 
@@ -57,7 +57,7 @@ public abstract class AbstractBox implements Box
    */
   public void setIndex(int index)
   {
-    this.index = new Integer(index);
+    this.index = Integer.valueOf(index);
     settings.setAttribute(this.getClass().getName() + ".index",index);
   }
 

--- a/src/de/willuhn/jameica/gui/input/DecimalInput.java
+++ b/src/de/willuhn/jameica/gui/input/DecimalInput.java
@@ -47,7 +47,7 @@ public class DecimalInput extends TextInput
    */
   public DecimalInput(double d, DecimalFormat format)
   {
-    this(Double.isNaN(d) ? null : new Double(d),format);
+    this((Double.isNaN(d) ? null : Double.valueOf(d)), format);
   }
 
   /**
@@ -149,7 +149,7 @@ public class DecimalInput extends TextInput
   public Object getValue()
   {
     Number n = this.getNumber();
-    return n == null ? null : new Double(n.doubleValue());
+    return n == null ? null : Double.valueOf(n.doubleValue());
   }
   
   /**

--- a/src/de/willuhn/jameica/gui/input/IntegerInput.java
+++ b/src/de/willuhn/jameica/gui/input/IntegerInput.java
@@ -71,7 +71,7 @@ public class IntegerInput extends TextInput
     if (value == null || value.toString().length() == 0)
       return null;
     try {
-      return new Integer(value.toString());
+      return Integer.valueOf(value.toString());
     }
     catch (NumberFormatException e)
     {

--- a/src/de/willuhn/jameica/gui/input/SpinnerInput.java
+++ b/src/de/willuhn/jameica/gui/input/SpinnerInput.java
@@ -97,9 +97,9 @@ public class SpinnerInput extends AbstractInput
   public Object getValue()
   {
     if (this.spinner == null || this.spinner.isDisposed())
-      return new Integer(this.value);
+      return Integer.valueOf(this.value);
     
-    return new Integer(this.spinner.getSelection());
+    return Integer.valueOf(this.spinner.getSelection());
   }
 
   /**

--- a/src/de/willuhn/jameica/gui/internal/controller/BackupControl.java
+++ b/src/de/willuhn/jameica/gui/internal/controller/BackupControl.java
@@ -186,7 +186,7 @@ public class BackupControl extends AbstractControl
         long size = ((Number) o).longValue();
         if (size == 0)
           return "-";
-        return format.format(new Double(size / 1024d /1024d));
+        return format.format(Double.valueOf(size / 1024d /1024d));
       }
     
     });

--- a/src/de/willuhn/jameica/gui/internal/controller/BackupControl.java
+++ b/src/de/willuhn/jameica/gui/internal/controller/BackupControl.java
@@ -276,7 +276,7 @@ public class BackupControl extends AbstractControl
     {
       Integer i = (Integer) getCount().getValue();
       config.setBackupCount(i == null ? -1 : i.intValue());
-      getCount().setValue(new Integer(config.getBackupCount())); // Reset, falls der User Unsinn eingegeben hat
+      getCount().setValue(Integer.valueOf(config.getBackupCount())); // Reset, falls der User Unsinn eingegeben hat
 
       config.setBackupDir((String)getTarget().getValue());
       getTarget().setValue(config.getBackupDir()); // Reset, falls der User Unsinn eingegeben hat

--- a/src/de/willuhn/jameica/gui/internal/views/Settings.java
+++ b/src/de/willuhn/jameica/gui/internal/views/Settings.java
@@ -214,7 +214,7 @@ public class Settings extends AbstractView implements Extendable
     Application.getMessagingFactory().getMessagingQueue(this.getExtendableID()).unRegisterMessageConsumer(this.mc);
     
     // Wir merken uns das aktive Tab
-    lastActiveTab = new Integer(getTabFolder().getSelectionIndex());
+    lastActiveTab = Integer.valueOf(getTabFolder().getSelectionIndex());
   }
 
   /**

--- a/src/de/willuhn/jameica/gui/parts/TablePart.java
+++ b/src/de/willuhn/jameica/gui/parts/TablePart.java
@@ -402,7 +402,7 @@ public class TablePart extends AbstractTablePart
           for (int i=0;i<this.columns.size();++i)
           {
             Column col   = this.columns.get(i);
-            List<Item> l = sortTable.get(new Integer(i));
+            List<Item> l = sortTable.get(Integer.valueOf(i));
             int pos      = l.indexOf(new Item(oldVersion,null));
             if (pos < 0)
             {
@@ -498,12 +498,12 @@ public class TablePart extends AbstractTablePart
       // Sortierung
       
       // Mal schauen, ob wir fuer die Spalte schon eine Sortierung haben
-      List<Item> l = sortTable.get(new Integer(i));
+      List<Item> l = sortTable.get(Integer.valueOf(i));
       if (l == null)
       {
         // Ne, also erstellen wir eine
         l = new LinkedList<Item>();
-        sortTable.put(new Integer(i),l);
+        sortTable.put(Integer.valueOf(i),l);
       }
 
       l.add(di);
@@ -701,7 +701,7 @@ public class TablePart extends AbstractTablePart
           try
           {
             state.put(getID() + ".object",event.data);
-            state.put(getID() + ".index",new Integer(table.getTopIndex()));
+            state.put(getID() + ".index", Integer.valueOf(table.getTopIndex()));
           }
           catch (Exception e)
           {
@@ -1305,7 +1305,7 @@ public class TablePart extends AbstractTablePart
     if (table == null || table.isDisposed())
       return;
 
-    List<Item> l = sortTable.get(new Integer(index));
+    List<Item> l = sortTable.get(Integer.valueOf(index));
     if (l == null)
       return; // nix zu sortieren.
 


### PR DESCRIPTION
als deprecated markierte Konstruktoren durch `.valueOf()`-Pendant ersetzt