### PR TITLE
Korrigiere Zuordnungen der Plugins

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -8,11 +8,11 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry exported="true" kind="lib" path="lib/nanoxml/nanoxml-2.2.3.jar" sourcepath="lib.src/nanoxml/nanoxml-2.2.3.src.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/swt/linux64/swt.jar" sourcepath="lib.src/swt/linux64/src.zip"/>
+	<classpathentry exported="true" kind="lib" path="lib/swt/win64/swt.jar" sourcepath="lib.src/swt/win6464/src.zip"/>
 	<classpathentry exported="true" kind="lib" path="lib/swt/org.eclipse.core.runtime_3.10.0.v20140318-2214.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/swt/org.eclipse.osgi_3.10.1.v20140909-1633.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/swt/org.eclipse.jface_3.10.1.v20140813-1009.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/swt/org.eclipse.ui.forms_3.6.100.v20140422-1825.jar" sourcepath="lib.src/swt/linux/swt.src.zip"/>
+	<classpathentry exported="true" kind="lib" path="lib/swt/org.eclipse.ui.forms_3.6.100.v20140422-1825.jar" sourcepath="lib.src/swt/win64/swt.src.zip"/>
 	<classpathentry exported="true" kind="lib" path="lib/de_willuhn_ds/de_willuhn_ds.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/de_willuhn_util/de_willuhn_util.jar"/>
 	<classpathentry kind="lib" path="lib/swtcalendar/swtcalendar.jar" sourcepath="lib.src/swtcalendar/swtcalendar.src.zip"/>

--- a/src/de/willuhn/jameica/gui/internal/parts/BackupVersionsList.java
+++ b/src/de/willuhn/jameica/gui/internal/parts/BackupVersionsList.java
@@ -107,14 +107,12 @@ public class BackupVersionsList extends TablePart
     // nach dem Restore verloren gehen
     List<Manifest> l = Application.getPluginLoader().getInstalledManifests();
     Hashtable<String,Manifest> installed = new Hashtable<String, Manifest>();
-    for (int i=0;i<l.size();++i)
-    {
-      Manifest mf = l.get(i);
-      installed.put(mf.getPluginClass(),mf);
-    }
+    
+    for(Manifest mf: l)
+      installed.put(mf.getPluginLabel(),mf);
     
     Properties props = file.getProperties();
-    Enumeration keys = props.keys();
+    Enumeration<Object> keys = props.keys();
     ArrayList<Plugin> list = new ArrayList<Plugin>();
     while (keys.hasMoreElements())
     {
@@ -140,19 +138,14 @@ public class BackupVersionsList extends TablePart
       pc = pc.substring(0,pc.lastIndexOf(".version"));
       
       // Ist im Backup enthalten. Aus der "installed"-Liste streichen
-      installed.remove(pc);
-      list.add(new Plugin(pc,new Version(version)));
+      list.add(new Plugin(pc, installed.remove(pc), new Version(version)));
     }
     
     // Jetzt checken wir, ob in der "installed"-Liste noch
     // was drin steht. Das sind die, zu denen kein Backup
     // vorliegt
-    Enumeration<String> missing = installed.keys();
-    while (missing.hasMoreElements())
-    {
-      String pc = missing.nextElement();
-      list.add(new Plugin(pc,null));
-    }
+    installed.forEach((pc,mf)
+        -> list.add(new Plugin(pc,mf,null)));
     return list;
   }
 
@@ -174,9 +167,10 @@ public class BackupVersionsList extends TablePart
     /**
      * ct.
      * @param pluginClass
+     * @param mf Manifest des installierten Plugins
      * @param backupVersion Version aus dem Backup
      */
-    private Plugin(String pluginClass, Version backupVersion)
+    private Plugin(String pluginClass, Manifest manifest, Version backupVersion)
     {
       this.pluginClass   = pluginClass;
       this.backupVersion = backupVersion;
@@ -184,26 +178,33 @@ public class BackupVersionsList extends TablePart
       this.name          = this.pluginClass;
       this.noBackup      = this.backupVersion == null;
 
-      // Checken, ob das Plugin installiert ist
-      de.willuhn.jameica.plugin.Plugin plugin = null;
-      try
+      //wenn kein Manifest vorgegeben wurde, lade das Plugin
+      if(manifest == null)
       {
-        plugin = Application.getPluginLoader().getPlugin(this.pluginClass);
-      }
-      catch (Exception e)
-      {
-        Logger.warn("unable to find plugin, consider as not-installed: " + e.getMessage());
-        Logger.write(Level.DEBUG,"stacktrace for debugging purpose",e);
+        // Checken, ob das Plugin installiert ist
+        de.willuhn.jameica.plugin.Plugin plugin = null;
+        try
+        {
+          plugin = Application.getPluginLoader().getPlugin(this.pluginClass);
+        }
+        catch (Exception e)
+        {
+          Logger.warn("unable to find plugin, consider as not-installed: " + e.getMessage());
+          Logger.write(Level.DEBUG,"stacktrace for debugging purpose",e);
+        }
+
+        // Plugin ist geladen. Hole das Manifest
+        if(plugin != null)
+          manifest = plugin.getManifest();
       }
 
-      this.notInstalled = plugin == null;
+      this.notInstalled = manifest == null;
 
-      if (plugin != null)
+      if (manifest != null)
       {
         // Plugin ist installiert. Versionsnummer checken
-        Manifest mf = plugin.getManifest();
-        this.name             = mf.getName();
-        this.currentVersion   = mf.getVersion();
+        this.name             = manifest.getName();
+        this.currentVersion   = manifest.getVersion();
         
         // Wir maengeln einen Versionskonflikt nur an, wenn die Version aus dem Backup
         // aktueller als die installierte ist. Sollte das Backup aelter sein, findet

--- a/src/de/willuhn/jameica/plugin/Manifest.java
+++ b/src/de/willuhn/jameica/plugin/Manifest.java
@@ -237,6 +237,38 @@ public class Manifest implements Comparable
   }
   
   /**
+   * Liefert den Bezeichner des Plugins, idealerweise ist dieser eindeutig.
+   * Im Allgemeinen entspricht das dem Klassen-Namen.
+   * Im Falle einer {@code Proxy} Instanz, wird der Namen der Komponente zurueck gegeben.
+   * @return Klassen-Name des Plugins oder Namen der Komponente.
+   */
+  public String getPluginLabel()
+  {
+    // Wenn das Plugin noch nicht geladen ist, betrachten wir die Beschreibung
+    if (this.pluginInstance == null)
+    {
+      String className = this.root.getAttribute("class",null);
+      
+      // normales Plugin
+      if (className != null)
+        return className.trim();
+      
+      // Das ist ein "Pseudo-Plugin" ohne eigene Plugin-Klasse. Wir laden das
+      // gleich hier, um den Namen der Klasse zu kriegen
+      this.pluginInstance = PlaceholderPlugin.createInstance(this);
+    }
+    
+    Class<?> clazz = this.pluginInstance.getClass();
+    
+    //Wenn es sich um eine Proxy-Instanz handelt, geben wir den Namen der Komponente zurueck
+    if(java.lang.reflect.Proxy.isProxyClass(clazz))
+        return getName();
+    
+    // normales Plugin
+    return clazz.getName();
+  }
+  
+  /**
    * Liefert zurueck, ob das Plugin ueber den globalen Classloader von Jameica geladen werden soll.
    * @return {@code true}, wenn es ueber den globalen Classloader geladen werden soll.
    * Andernfalls erhaelt es einen exlusiven Classloader.


### PR DESCRIPTION
Beim Wiederherstellen eines Backups werden die verfügbaren und die im Backup verwendeten Plugins gegenübergestellt.

Sind die Plugins via Proxy-Klassen geladen, schlägt die Zuordnung fehl. Das führt zu einer unschönen, verwirrenden, teils fehlerhaften Darstellung.

Vorher:
![01bugged](https://user-images.githubusercontent.com/5089754/149682020-52e0b2dd-2401-4475-9efc-9d78e43baf5e.png)

Nachher:
![02patched](https://user-images.githubusercontent.com/5089754/149682022-31b93cfe-a24e-4dbc-be3e-438874993875.png)
