### PR TITLE
display serials of certificates as hex

### DIFF
--- a/src/de/willuhn/jameica/gui/dialogs/AbstractCertificateDialog.java
+++ b/src/de/willuhn/jameica/gui/dialogs/AbstractCertificateDialog.java
@@ -206,7 +206,7 @@ public abstract class AbstractCertificateDialog extends AbstractDialog
     // Details
     DateFormat df = DateUtil.DEFAULT_FORMAT;
     this.validity.setValue(i18n.tr("{0} - {1}",df.format(cert.getNotBefore()),df.format(cert.getNotAfter())));
-    this.serial.setValue(cert.getSerialNumber().toString());
+    this.serial.setValue("0x" + cert.getSerialNumber().toString(16).toUpperCase());
     /////////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////////

--- a/src/de/willuhn/jameica/gui/internal/parts/CertificateList.java
+++ b/src/de/willuhn/jameica/gui/internal/parts/CertificateList.java
@@ -321,7 +321,7 @@ public class CertificateList extends TablePart
         return s;
       }
       if ("serial".equals(arg0))
-        return cert.getSerialNumber().toString();
+        return "0x" + cert.getSerialNumber().toString(16).toUpperCase();
       if ("organization".equals(arg0))
         return myCert.getSubject().getAttribute(Principal.ORGANIZATION);
       if ("ou".equals(arg0))

--- a/src/de/willuhn/jameica/security/JameicaTrustManager.java
+++ b/src/de/willuhn/jameica/security/JameicaTrustManager.java
@@ -321,7 +321,7 @@ public class JameicaTrustManager implements X509TrustManager
     sb.append(" to: ");
     sb.append(cert.getNotAfter().toString());
     sb.append("][serial: ");
-    sb.append(cert.getSerialNumber().toString());
+    sb.append("0x" + cert.getSerialNumber().toString(16).toUpperCase());
     sb.append("]");
     return sb.toString();
   }

--- a/src/de/willuhn/jameica/system/ApplicationCallbackConsole.java
+++ b/src/de/willuhn/jameica/system/ApplicationCallbackConsole.java
@@ -490,7 +490,7 @@ public class ApplicationCallbackConsole extends AbstractApplicationCallback
     System.out.println((i18n.tr("Ausgestellt für:      ") + cert.getSubjectDN().getName()));
     System.out.println((i18n.tr("Gültig von:           ") + df.format(cert.getNotBefore())));
     System.out.println((i18n.tr("Gültig bis:           ") + df.format(cert.getNotAfter())));
-    System.out.println((i18n.tr("Seriennummer:         ") + cert.getSerialNumber().toString()));
+    System.out.println((i18n.tr("Seriennummer:         ") + "0x" + cert.getSerialNumber().toString(16).toUpperCase()));
     System.out.println((i18n.tr("Typ:                  ") + cert.getType()));
     System.out.println((i18n.tr("SHA1-Fingerabdruck:   ") + myCert.getSHA1Fingerprint()));
     System.out.println((i18n.tr("SHA256-Fingerabdruck: ") + myCert.getSHA256Fingerprint()));


### PR DESCRIPTION
Seriennummern von (SSL-)Zertifikaten werden häufig hexadezimal dargestellt, bspw. in Firefox und Windows-Zertifikatsansicht. Zur besseren Vergleichbarkeit und ggf. manuellen Validierung von Zertifikaten werden diese nun auch in Jameica hexadezimal angezeigt, statt vorher dezimal.