### PR TITLE
Classpath von SWT wieder auf Linux64 gesetzt

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -8,7 +8,7 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry exported="true" kind="lib" path="lib/nanoxml/nanoxml-2.2.3.jar" sourcepath="lib.src/nanoxml/nanoxml-2.2.3.src.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/swt/win64/swt.jar" sourcepath="lib.src/swt/linux64/src.zip"/>
+	<classpathentry exported="true" kind="lib" path="lib/swt/linux64/swt.jar" sourcepath="lib.src/swt/linux64/src.zip"/>
 	<classpathentry exported="true" kind="lib" path="lib/swt/org.eclipse.ui.forms_3.6.100.v20140422-1825.jar" sourcepath="lib.src/swt/win64/swt.src.zip"/>
 	<classpathentry exported="true" kind="lib" path="lib/de_willuhn_ds/de_willuhn_ds.jar" sourcepath="/datasource/src"/>
 	<classpathentry exported="true" kind="lib" path="lib/de_willuhn_util/de_willuhn_util.jar" sourcepath="/util/src"/>


### PR DESCRIPTION
Starten von Hibiscus in Eclipse scheitert an  

    [INFO][main][de.willuhn.jameica.system.StartupParams.<init>] starting in STANDALONE mode
    Exception in thread "main" java.lang.UnsatisfiedLinkError: Could not load SWT library.

Der erste Pfad zu swt.jar in `.classpath` muss wieder auf Linux gesetzt werden.

Dieselbe Änderung wie  https://github.com/willuhn/jameica/commit/29c6aec940430dfedfb2134921f8d34cfe0354af im Januar 2022.

Ich nehme an die Zeile darunter ist das swt.jar für Windows.(?)
