### PR TITLE
Neue Option: Master-Passwort via Command übergeben

### DIFF
--- a/src/de/willuhn/jameica/system/ApplicationCallbackConsole.java
+++ b/src/de/willuhn/jameica/system/ApplicationCallbackConsole.java
@@ -124,6 +124,13 @@ public class ApplicationCallbackConsole extends AbstractApplicationCallback
 			Logger.debug("master password given via commandline");
 			return this.password;
 		}
+
+		this.password = Application.getStartupParams().getPasswordUsingCommand();
+		if (this.password != null && this.password.length() > 0)
+		{
+			Logger.debug("master password given via command specified in commandline");
+			return this.password;
+		}
 		
 		// Eingabe ueberhaupt moeglich?
     if (Application.inNonInteractiveMode())
@@ -226,6 +233,9 @@ public class ApplicationCallbackConsole extends AbstractApplicationCallback
     ////////////////////////////////////////////////////////////////////////////
     // Passwort via Kommandozeile angegeben?
     this.password = Application.getStartupParams().getPassword();
+    if (this.password == null || this.password.length() == 0) {
+      this.password = Application.getStartupParams().getPasswordUsingCommand();
+    }
 
     if (this.password != null && this.password.length() > 0)
     {

--- a/src/de/willuhn/jameica/system/ApplicationCallbackSWT.java
+++ b/src/de/willuhn/jameica/system/ApplicationCallbackSWT.java
@@ -81,6 +81,13 @@ public class ApplicationCallbackSWT extends AbstractApplicationCallback
 			Logger.info("master password given via commandline");
 			return this.password;
 		}
+
+		this.password = Application.getStartupParams().getPasswordUsingCommand();
+		if (this.password != null && this.password.length() > 0)
+		{
+			Logger.debug("master password given via command specified in commandline");
+			return this.password;
+		}
 			
     NewPWD p = new NewPWD(NewPWD.POSITION_CENTER);
   	String text = Application.getI18n().tr("Sie starten die Anwendung zum ersten Mal.\n\n" +
@@ -129,6 +136,9 @@ public class ApplicationCallbackSWT extends AbstractApplicationCallback
 
     // Haben wir ein Passwort via Kommandozeilen-Parameter?
     this.password = Application.getStartupParams().getPassword();
+    if (this.password == null || this.password.length() == 0) {
+      this.password = Application.getStartupParams().getPasswordUsingCommand();
+    }
     if (this.password != null && this.password.length() > 0)
     {
       Logger.info("master password given via commandline");


### PR DESCRIPTION
Ich verwende einen Passwort-Manager. Ich möchte daher gerne mein Master-Passwort in diesem Passwort-Manager speichern.
Die Option "Passwortdatei" bewirkt allerdings, dass bei Hibiscus die Option PINs permanent zu speichern deaktiviert wird.

Dieser PR fügt eine neue Option `-P` hinzu, mit der ein Command zur Ermittlung des Passworts übergeben werden kann.
Da das nicht unsicherer als eine manuelle Eingabe des Master-Passworts ist, muss auch die PIN-Speicher-Option hierbei nicht deaktiviert werden.