### PR TITLE
Schriftfarbe bei Dropdown Pflichtferldern auf Schwarz setzen

### DIFF
--- a/src/de/willuhn/jameica/gui/input/AbstractInput.java
+++ b/src/de/willuhn/jameica/gui/input/AbstractInput.java
@@ -325,6 +325,7 @@ public abstract class AbstractInput implements Input
       if (isMandatory() && (value == null || "".equals(value.toString())))
       {
         this.control.setBackground(Color.MANDATORY_BG.getSWTColor());
+        this.control.setForeground(Color.BLACK.getSWTColor());
         return;
       }
       this.control.setBackground(null);


### PR DESCRIPTION
Bei Dropdown Pflichtfeldern ist jetzt die Hintergrundfarbe die unter Einstellungen gewählte Farbe. Der Text ist jedoch immer weiß, wo das man es kaum lesen kann. Mit diesem Patch wird die Farbe Schawarz dargestellt.