### PR TITLE
Date input: Fixes, Eingabehilfen und Tastenkombinationen

### DIFF
--- a/src/de/willuhn/jameica/gui/input/DateInput.java
+++ b/src/de/willuhn/jameica/gui/input/DateInput.java
@@ -104,6 +104,8 @@ public class DateInput implements Input
     this.dialog.setTitle(Application.getI18n().tr("Datum"));
     this.dialog.setText(Application.getI18n().tr("Bitte wählen Sie das Datum aus"));
     this.input = new DialogInput(date == null ? null : this.format.format(date), this.dialog);
+    this.input.setData(DATAKEY_TOOLTIP, String.format(Application.getI18n().tr("DateInput.tooltip")));
+
     setupFocusListener();
     setupKeyListener();
   }

--- a/src/de/willuhn/jameica/gui/input/DateInput.java
+++ b/src/de/willuhn/jameica/gui/input/DateInput.java
@@ -12,7 +12,6 @@ package de.willuhn.jameica.gui.input;
 
 import java.text.DateFormat;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.HashMap;
@@ -76,29 +75,38 @@ public class DateInput implements Input
    * @param date das Datum.
    * @param format das Format.
    */
-  public DateInput(Date date, DateFormat format)
-  {
+  public DateInput(Date date, DateFormat format) {
     if (format != null)
       this.format = format;
-    
+
     this.dialog = new MyCalendarDialog();
-    
+
     if (date != null)
       this.dialog.setDate(date);
-    
+
     this.dialog.addCloseListener(new Listener() {
-    
-      public void handleEvent(Event event)
-      {
+
+      public void handleEvent(Event event) {
         if (event == null || event.data == null)
           return;
         input.setText(DateInput.this.format.format((Date) event.data));
       }
     });
-    
+
     this.dialog.setTitle(Application.getI18n().tr("Datum"));
     this.dialog.setText(Application.getI18n().tr("Bitte wählen Sie das Datum aus"));
-    this.input = new DialogInput(date == null ? null : this.format.format(date),this.dialog);
+    this.input = new DialogInput(date == null ? null : this.format.format(date), this.dialog);
+    setupFocusListener();
+  }
+
+  private void setupFocusListener() {
+    this.input.addFocusListener(new FocusAdapter() {
+      @Override
+      public void focusLost(FocusEvent e) {
+        //Automatische Formatierung bei Focus-Lost des Eingabefeldes
+        getValue();
+      }
+    });
   }
 
   /**
@@ -263,16 +271,6 @@ public class DateInput implements Input
   {
     this.input.setMandatory(this.isMandatory());
     this.input.paint(parent);
-    
-    this.input.getControl().addFocusListener(new FocusAdapter() {
-      @Override
-      public void focusLost(FocusEvent e)
-      {
-        //Automatische Formatierung bei Focus-Lost des Eingabefeldes
-        getValue();
-      }
-    });
-
   }
 
   @Override

--- a/src/de/willuhn/jameica/gui/input/DateInput.java
+++ b/src/de/willuhn/jameica/gui/input/DateInput.java
@@ -138,28 +138,28 @@ public class DateInput implements Input
   {
     // Wir liefern grundsaetzlich den Text aus dem Eingabe-Feld,
     // damit der User das Datum auch manuell eingeben kann.
-    String text = this.input.getText();
-    if (text == null || text.length() == 0)
+    String inputText = this.input.getText();
+    if (inputText == null || inputText.length() == 0)
       return null;
 
-    text = DateUtil.convert2Date(text);
+    String convertedText = DateUtil.convert2Date(inputText);
     try
     {
-      Date d = this.format.parse(text);
+      Date d = this.format.parse(convertedText);
       
       // Bei der Gelegenheit schreiben wir auch gleich nochmal
       // das Datum schoen formatiert rein. Aber nur, wenn sich der
       // Wert geaendert hat. Sonst springt der Cursor unnoetig
       // an den Anfang des Eingabefeldes. Siehe BUGZILLA 1672
       String newText = this.format.format(d);
-      if (!StringUtils.equals(text, newText))
+      if (!StringUtils.equals(inputText, newText))
         this.input.setText(newText);
       
       return d;
     }
     catch (ParseException e)
     {
-      Application.getMessagingFactory().sendMessage(new StatusBarMessage(Application.getI18n().tr("Ungültiges Datum: {0}",text),StatusBarMessage.TYPE_ERROR));
+      Application.getMessagingFactory().sendMessage(new StatusBarMessage(Application.getI18n().tr("Ungültiges Datum: {0}",inputText),StatusBarMessage.TYPE_ERROR));
       return null;
     }
   }

--- a/src/de/willuhn/jameica/gui/input/DateInput.java
+++ b/src/de/willuhn/jameica/gui/input/DateInput.java
@@ -92,24 +92,27 @@ public class DateInput implements Input
     if (date != null)
       this.dialog.setDate(date);
 
-    this.dialog.addCloseListener(new Listener() {
+    this.dialog.setTitle(Application.getI18n().tr("Datum"));
+    this.dialog.setText(Application.getI18n().tr("Bitte wählen Sie das Datum aus"));
+    this.input = new DialogInput(date == null ? null : this.format.format(date), this.dialog);
+    this.input.setData(DATAKEY_TOOLTIP, String.format(Application.getI18n().tr("DateInput.tooltip")));
 
+    setupDialogCloseListener();
+    setupFocusListener();
+    setupKeyListener();
+  }
+
+  private void setupDialogCloseListener() {
+    this.dialog.addCloseListener(new Listener() {
+      @Override
       public void handleEvent(Event event) {
         if (event == null || event.data == null)
           return;
         input.setText(DateInput.this.format.format((Date) event.data));
       }
     });
-
-    this.dialog.setTitle(Application.getI18n().tr("Datum"));
-    this.dialog.setText(Application.getI18n().tr("Bitte wählen Sie das Datum aus"));
-    this.input = new DialogInput(date == null ? null : this.format.format(date), this.dialog);
-    this.input.setData(DATAKEY_TOOLTIP, String.format(Application.getI18n().tr("DateInput.tooltip")));
-
-    setupFocusListener();
-    setupKeyListener();
   }
-
+  
   private void setupFocusListener() {
     this.input.addFocusListener(new FocusAdapter() {
       @Override

--- a/src/de/willuhn/jameica/gui/input/DialogInput.java
+++ b/src/de/willuhn/jameica/gui/input/DialogInput.java
@@ -9,6 +9,9 @@
  **********************************************************************/
 package de.willuhn.jameica.gui.input;
 
+import java.util.ArrayList;
+
+import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
@@ -47,6 +50,8 @@ public class DialogInput extends ButtonInput
   private AbstractDialog dialog;
   private Object choosen;
   private int maxlength = 0;
+  
+  private ArrayList<FocusListener> focusListeners = new ArrayList<>();
 
   private Object oldValue = PLACEHOLDER;
 
@@ -121,7 +126,8 @@ public class DialogInput extends ButtonInput
   {
 		if (text != null && !text.isDisposed())
 			return text.getText();
-  	return value;
+
+    return value;
   }
 
 	/**
@@ -174,13 +180,25 @@ public class DialogInput extends ButtonInput
   	this.choosen = value;
   }
 
+  public void addFocusListener(FocusListener listener) {
+    this.focusListeners.add(listener);
+  }
+
   @Override
   public Control getClientControl(Composite parent) {
+    if (text != null) {
+      return text;
+    }
     text = GUI.getStyleFactory().createText(parent);
   	if (value != null)
   		text.setText(value);
+
     if (this.maxlength > 0)
       text.setTextLimit(this.maxlength);
+
+    for (FocusListener l: focusListeners) {
+      this.text.addFocusListener(l);
+    }
 
   	return text;
   }

--- a/src/de/willuhn/jameica/gui/input/DialogInput.java
+++ b/src/de/willuhn/jameica/gui/input/DialogInput.java
@@ -183,7 +183,8 @@ public class DialogInput extends ButtonInput
   }
 
   public void setSelection(int start, int end) {
-    this.text.setSelection(start, end);
+    if (this.text != null && !this.text.isDisposed())
+        this.text.setSelection(start, end);
   }
 
   public void addFocusListener(FocusListener listener) {

--- a/src/de/willuhn/jameica/gui/input/DialogInput.java
+++ b/src/de/willuhn/jameica/gui/input/DialogInput.java
@@ -12,6 +12,7 @@ package de.willuhn.jameica.gui.input;
 import java.util.ArrayList;
 
 import org.eclipse.swt.events.FocusListener;
+import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
@@ -44,7 +45,7 @@ import de.willuhn.logging.Logger;
  */
 public class DialogInput extends ButtonInput
 {
-  private final static Object PLACEHOLDER = new Object();
+  private static final Object PLACEHOLDER = new Object();
 
 	private Text text;
   private AbstractDialog dialog;
@@ -52,6 +53,7 @@ public class DialogInput extends ButtonInput
   private int maxlength = 0;
   
   private ArrayList<FocusListener> focusListeners = new ArrayList<>();
+  private ArrayList<KeyListener> keyListeners = new ArrayList<>();
 
   private Object oldValue = PLACEHOLDER;
 
@@ -180,8 +182,16 @@ public class DialogInput extends ButtonInput
   	this.choosen = value;
   }
 
+  public void setSelection(int start, int end) {
+    this.text.setSelection(start, end);
+  }
+
   public void addFocusListener(FocusListener listener) {
     this.focusListeners.add(listener);
+  }
+
+  public void addKeyListener(KeyListener listener) {
+    this.keyListeners.add(listener);
   }
 
   @Override
@@ -198,6 +208,9 @@ public class DialogInput extends ButtonInput
 
     for (FocusListener l: focusListeners) {
       this.text.addFocusListener(l);
+    }
+    for (KeyListener l: keyListeners) {
+      this.text.addKeyListener(l);
     }
 
   	return text;

--- a/src/de/willuhn/jameica/util/DateUtil.java
+++ b/src/de/willuhn/jameica/util/DateUtil.java
@@ -13,6 +13,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 
 import de.willuhn.jameica.gui.formatter.DateFormatter;
 import de.willuhn.jameica.system.Application;
@@ -23,16 +24,46 @@ import de.willuhn.jameica.system.Application;
 public class DateUtil
 {
   /**
-   * Das Default-Dateformat von Jameica (dd.mm.yyyy).
-   * Abhaengig vom Locale.
+   * Das Default-Dateformat von Jameica.
+   * Abhaengig vom Locale,
+   * z. B. deutsch: dd.MM.yyyy / englisch: MMM d, yyyy
    */
-  public final static DateFormat DEFAULT_FORMAT = SimpleDateFormat.getDateInstance(DateFormat.DEFAULT,Application.getConfig().getLocale());
-  
+  public static volatile DateFormat DEFAULT_FORMAT;
   /**
-   * Das Kurz-Dateformat von Jameica (dd.mm.yy).
-   * Abhaengig vom Locale.
+   * Das Kurz-Dateformat von Jameica.
+   * Abhaengig vom Locale,
+   * z. B. deutsch: dd.MM.yy / englisch: MM/dd/yyyy
    */
-  public final static DateFormat SHORT_FORMAT   = SimpleDateFormat.getDateInstance(DateFormat.SHORT,Application.getConfig().getLocale());
+  public static volatile DateFormat SHORT_FORMAT;
+
+  static {
+    initializeLocale();
+  }
+
+  /**
+   * Wird diese Klasse getestet, existiert die Application-Instanz nicht
+   * und wir können das Locale nicht aus der Config lesen.
+   */
+  private static void initializeLocale() {
+    Locale locale;
+    try {
+      locale = Application.getConfig().getLocale();
+    } catch (NullPointerException e) {
+      // Fallback, falls Application noch nicht initialisiert wurde (für Tests)
+      locale = Locale.GERMANY;
+    }
+    DEFAULT_FORMAT = SimpleDateFormat.getDateInstance(DateFormat.DEFAULT, locale);
+    SHORT_FORMAT = SimpleDateFormat.getDateInstance(DateFormat.SHORT, locale);
+  }
+
+  /**
+   * Überschreibt das von der Config vorgegebene Locale (für Tests)
+   * @param locale
+   */
+  public static void setLocaleForTesting(Locale locale) {
+    DEFAULT_FORMAT = DateFormat.getDateInstance(DateFormat.DEFAULT, locale);
+    SHORT_FORMAT = DateFormat.getDateInstance(DateFormat.SHORT, locale);
+  }
 
   /**
    * Eingabehilfe für Datumsfelder. Eine 1-2stellige Zahl wird als Tag des

--- a/src/de/willuhn/jameica/util/DateUtil.java
+++ b/src/de/willuhn/jameica/util/DateUtil.java
@@ -130,9 +130,9 @@ public class DateUtil
    * - "h" (heute) | "t" (today)<br>
    * - +D | -D (heute plus/minus D Tage)<br>
    * - ++M | --M (heute plus/minus M Monate)<br>
-   * Das Datum muss immer in der Reihenfolge "Tag - Monat - Jahr" angegeben werden (auch im defaultFormatter).
+   * Das Datum muss immer in der Reihenfolge "Tag - Monat - Jahr" angegeben werden (auch im customFormatter).
    * @param userInput Eingabetext
-   * @param customFormatter Standardformat, das das Datumsfeld nutzt, um das Datum anzuzeigen
+   * @param customFormatter Formatter, den das Datumsfeld nutzt, um das Datum anzuzeigen
    * @return das geparste Datum als Optional
    */
   public static Optional<LocalDate> parseUserInput(String userInput, DateTimeFormatter customFormatter) {
@@ -186,16 +186,17 @@ public class DateUtil
     if (userInput.length() == 1) {
       userInput = "0" + userInput;
     }
+    LocalDate now = LocalDate.now();
     DateTimeFormatter inputFormatter = new DateTimeFormatterBuilder()
         .appendPattern(dayPattern)
         .optionalStart()
         .appendPattern(monthPattern)
         .optionalStart()
-        .appendValueReduced(ChronoField.YEAR, 2, 4, LocalDate.now().getYear() - 80)
+        .appendValueReduced(ChronoField.YEAR, 2, 4, now.getYear() - 80)
         .optionalEnd()
         .optionalEnd()
-        .parseDefaulting(ChronoField.MONTH_OF_YEAR, LocalDate.now().getMonthValue())
-        .parseDefaulting(ChronoField.YEAR, LocalDate.now().getYear())
+        .parseDefaulting(ChronoField.MONTH_OF_YEAR, now.getMonthValue())
+        .parseDefaulting(ChronoField.YEAR, now.getYear())
         .toFormatter();
     return parseDateUsingFormatter(userInput, inputFormatter);
   }
@@ -257,25 +258,25 @@ public class DateUtil
   
   /**
    * Versucht aus einem java.text.DateFormat einen java.time.format.DateTimeFormatter zu erstellen.
-   * @param dtFormat Das DateFormat. Eine Konvertierung ist nur möglich, wenn es
-   *                 instanceof java.text.SimpleDateFormat ist. Andernfalls wird
-   *                 das {@link DEFAULT_FORMAT} verwendet.
+   * @param dFormat Das DateFormat. Eine Konvertierung ist nur möglich, wenn es
+   *                instanceof java.text.SimpleDateFormat ist. Andernfalls wird
+   *                das {@link DEFAULT_FORMAT} verwendet.
    * @return der DateTimeFormatter
    */
-  public static DateTimeFormatter createDateTimeFormatter(DateFormat dtFormat) {
-    if (dtFormat.equals(DEFAULT_FORMAT)) {
+  public static DateTimeFormatter createDateTimeFormatter(DateFormat dFormat) {
+    if (dFormat.equals(DEFAULT_FORMAT)) {
       return defaultFormatter;
     }
-    if (dtFormat.equals(SHORT_FORMAT)) {
+    if (dFormat.equals(SHORT_FORMAT)) {
       return shortFormatter;
     }
-    if (!(dtFormat instanceof SimpleDateFormat)) {
+    if (!(dFormat instanceof SimpleDateFormat)) {
       // nur bei einem SimpleDateFormat existiert .toPattern()
       Logger.warn("Unable to create DateTimeFormatter from custom DateFormat. Using default Formatter");
       return defaultFormatter;
     }
     
-    String sdPattern = ((SimpleDateFormat)dtFormat).toPattern();    
+    String sdPattern = ((SimpleDateFormat)dFormat).toPattern();    
     String dateTimeFormatterPattern = sdPattern.replace("y", "u");
     
     return DateTimeFormatter.ofPattern(dateTimeFormatterPattern);
@@ -320,7 +321,6 @@ public class DateUtil
    * - Der DateTimeFormatter darf Tag/Monat/Jahr nur als Zahlen erzeugen, keine Monatsnamen o. Ä.<br>
    * - Tag- und Monatsfelder müssen 2-stellig sein<br>
    * - Die Reihenfolge Tag - Monat - Jahr muss eingehalten werden, siehe auch: {@link #parseUserInput(String, DateTimeFormatter)}
-   * - Für 3-stellige Jahre kann die Länge falsch sein
    * @param dtFormatter der DateTimeFormatter
    * @return alle Positionen für diesen DateTimeFormatter
    */
@@ -419,6 +419,15 @@ public class DateUtil
           this.dayWidth == other.dayWidth() &&
           this.monthIndex == other.monthIndex() &&
           this.monthWidth == other.monthWidth();
+    }
+    
+    @Override
+    public int hashCode() {
+      int result = Integer.hashCode(dayIndex);
+      result = 31 * result + Integer.hashCode(dayWidth);
+      result = 31 * result + Integer.hashCode(monthIndex);
+      result = 31 * result + Integer.hashCode(monthWidth);
+      return result;
     }
   }
 }

--- a/src/lang/system_messages_de_DE.properties
+++ b/src/lang/system_messages_de_DE.properties
@@ -1,0 +1,1 @@
+DateInput.tooltip=Eingabehilfen:%n- Datum ohne Punkte z. B. 12 oder 1203%n- Relative Tagesangaben, z. B. +3 oder -3%n- Relative Monatsangaben, z. B. ++6 oder --6%n- h für heute%n%nTastenkombinationen:%nAlt + Bild hoch/runter: Tag +/-%nAlt + Shift + Bild hoch/runter: Monat +/-

--- a/src/lang/system_messages_en.properties
+++ b/src/lang/system_messages_en.properties
@@ -358,3 +358,5 @@ Das\ Zertifikat\ des\ Repositories\ wurde\ ge\u00E4ndert\!\nM\u00F6chten\ Sie\ d
 Bitte\ geben\ Sie\ das\ Verzeichnis\ an,\ in\ dem\ Sie\ das\ Zertifikat\ speichern\ m\u00F6chten=Please\ select\ folder\ to\ save\ the\ certificate
 Sprache=Language
 &Navigation\ ein-/ausblenden=Show/Hide &navigation
+dd.MM.uuuu=dd/MM/uuuu
+dd.MM.uu=dd/MM/uu

--- a/src/lang/system_messages_en.properties
+++ b/src/lang/system_messages_en.properties
@@ -360,3 +360,4 @@ Sprache=Language
 &Navigation\ ein-/ausblenden=Show/Hide &navigation
 dd.MM.uuuu=dd/MM/uuuu
 dd.MM.uu=dd/MM/uu
+DateInput.tooltip=Input aids:%n- Date without slashes, e.g. 12 or 1203%n- Relative input of the day, e.g. +3 or -3%n- Relative input of the month, e.g. ++6 or --6%n- t for today%n%nKeyboard shortcuts:%nAlt + Page up/down: Day +/-%nAlt + Shift + Page up/down: Month +/-

--- a/test/de/willuhn/jameica/util/DateUtilTest.java
+++ b/test/de/willuhn/jameica/util/DateUtilTest.java
@@ -1,0 +1,72 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2024 Olaf Willuhn
+ * All rights reserved.
+ *
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details.
+ *
+ **********************************************************************/
+
+package de.willuhn.jameica.util;
+
+import java.time.LocalDate;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class DateUtilTest {
+
+    @Test
+    public void convert2Date() throws Exception {
+        DateUtil.setLocaleForTesting(Locale.GERMAN);
+        LocalDate today = LocalDate.now();
+        int currentYear = today.getYear();
+        int currentMonth = today.getMonthValue(); // 1 = Jan
+        int currentDay = today.getDayOfMonth();
+        int lastDayOfFebruary = LocalDate.of(currentYear, 3, 1).minusDays(1).getDayOfMonth();
+        String[][] testStrings = {
+                // input, expected output
+                // === valid dates ===
+                {"01.02.2023", "01.02.2023"},
+                {"02032024", "02.03.2024"},
+                {"0304", String.format("03.04.%d", currentYear)},
+                {"04", String.format("04.%02d.%d", currentMonth, currentYear)},
+                {"5", String.format("05.%02d.%d", currentMonth, currentYear)},
+                {"6.7.2028", "06.07.2028"},
+                {"7.8.29", "07.08.2029"},
+                //{"8.9.", String.format("08.09.%d", currentYear)},
+                // special shortcuts
+                //{"h", String.format("%02d.%02d.%d", currentDay, currentMonth, currentYear)},
+                //{"g", },
+                //{"+60", },
+                //{"-60", },
+                //{"++15", },
+                //{"--15", },
+                //{"3002", String.format("%02d.02.%d", lastDayOfFebruary, currentYear)},
+                //{"30022024", "29.02.2024"},
+                //{"30.02.2024", "29.02.2024"},
+                // === invalid dates ===
+                {"0113", "0113"},
+                {"01132024", "01132024"},
+                //{"01.13.2024", "01.13.2024"},
+                {"01.012.2023", "01.012.2023"},
+                {"01.02.2023 13:37", "01.02.2023 13:37"},
+                {"01.02.2023 invalid", "01.02.2023 invalid"},
+                {"123", "123"},
+                {"0", "0"},
+                {"01023", "01023"},
+                {"09.10", "09.10"},
+                {"2023-02-01", "2023-02-01"},
+                {"invalid", "invalid"},
+        };
+        for (int i = 0; i < testStrings.length; i++) {
+            Assert.assertEquals(
+                    testStrings[i][1], // expected
+                    DateUtil.convert2Date(testStrings[i][0])  // actual
+            );
+        }
+    }
+}

--- a/test/de/willuhn/jameica/util/DateUtilTest.java
+++ b/test/de/willuhn/jameica/util/DateUtilTest.java
@@ -10,8 +10,11 @@
 
 package de.willuhn.jameica.util;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -125,9 +128,9 @@ public class DateUtilTest {
 
   @Test
   public void convert2DateValid() throws Exception {
-    DateUtil.setLocaleForTesting(Locale.GERMAN);
-    String expected = "input | converted%n";
-    String actual = "input | converted%n";
+    DateUtil.setLocaleForTesting(Locale.GERMAN, "dd.MM.uuuu", "dd.MM.uu");
+    String expected = String.format("input | converted%n");
+    String actual = String.format("input | converted%n");
     for (int i = 0; i < validDates.length; i++) {
       String input = validDates[i][0];
       String result = DateUtil.convert2Date(input);
@@ -139,8 +142,9 @@ public class DateUtilTest {
 
   @Test
   public void convert2DateInvalid() throws Exception {
-    String expected = "input | converted%n";
-    String actual = "input | converted%n";
+    DateUtil.setLocaleForTesting(Locale.GERMAN, "dd.MM.uuuu", "dd.MM.uu");
+    String expected = String.format("input | converted%n");
+    String actual = String.format("input | converted%n");
     for (int i = 0; i < invalidDates.length; i++) {
       String input = invalidDates[i];
       String converted = DateUtil.convert2Date(input);
@@ -152,11 +156,11 @@ public class DateUtilTest {
 
   @Test
   public void parseUserInputValid() throws Exception {
-    DateUtil.setLocaleForTesting(Locale.GERMAN);
+    DateUtil.setLocaleForTesting(Locale.GERMAN, "dd.MM.uuuu", "dd.MM.uu");
 
     DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("dd.MM.uuuu");
-    String expected = "input | parsed%n";
-    String actual = "input | parsed%n";
+    String expected = String.format("input | parsed%n");
+    String actual = String.format("input | parsed%n");
     for (int i = 0; i < validDates.length; i++) {
       String input = validDates[i][0];
       expected += String.format ("%s | %s%n", input, validDates[i][1]);
@@ -170,9 +174,9 @@ public class DateUtilTest {
 
   @Test
   public void parseUserInputInvalid() throws Exception {
-    DateUtil.setLocaleForTesting(Locale.GERMAN);
-    String expected = "input | parsingSucceeded%n";
-    String actual = "input | parsingSucceeded%n";
+    DateUtil.setLocaleForTesting(Locale.GERMAN, "dd.MM.uuuu", "dd.MM.uu");
+    String expected = String.format("input | parsingSucceeded%n");
+    String actual = String.format("input | parsingSucceeded%n");
     for (int i = 0; i < invalidDates.length; i++) {
       String input = invalidDates[i];
       Optional<LocalDate> parsed = DateUtil.parseUserInput(input, null);
@@ -184,7 +188,7 @@ public class DateUtilTest {
 
   @Test
   public void parseUserInputUsingCustomFormatter() throws Exception {
-    DateUtil.setLocaleForTesting(Locale.GERMAN);
+    DateUtil.setLocaleForTesting(Locale.GERMAN, "dd.MM.uuuu", "dd.MM.uu");
     String inputDate = "01---02//2023";
 
     Optional<LocalDate> parsedDate = DateUtil.parseUserInput(inputDate, null);
@@ -193,5 +197,49 @@ public class DateUtilTest {
     DateTimeFormatter customFormatter = DateTimeFormatter.ofPattern("dd---MM//uuuu");
     parsedDate = DateUtil.parseUserInput(inputDate, customFormatter);
     Assert.assertEquals(Optional.of(LocalDate.of(2023, 2, 1)), parsedDate);
+  }
+  
+  @Test
+  public void createDateTimeFormatter() throws Exception {
+    DateUtil.setLocaleForTesting(Locale.ITALIAN, "uuuu-MM-dd", "uu-MM-dd");
+    
+    Date dNow = new Date();
+    LocalDate ldToday = LocalDate.now();
+    
+    DateFormat df;
+    DateTimeFormatter dtf;
+    
+    // DEFAULT_FORMAT
+    df = new SimpleDateFormat("yyyy-MM-dd");
+    dtf = DateUtil.createDateTimeFormatter(df);
+    Assert.assertEquals(df.format(dNow), dtf.format(ldToday));
+    
+    // SHORT_FORMAT
+    df = new SimpleDateFormat("yy-MM-dd");
+    dtf = DateUtil.createDateTimeFormatter(df);
+    Assert.assertEquals(df.format(dNow), dtf.format(ldToday));
+    
+    // custom format
+    df = new SimpleDateFormat("MM--yyyy...dd");
+    dtf = DateUtil.createDateTimeFormatter(df);
+    Assert.assertEquals(df.format(dNow), dtf.format(ldToday));
+  }
+
+  @Test
+  public void localDate2Date() throws Exception {
+    DateUtil.setLocaleForTesting(Locale.GERMAN, "dd.MM.uuuu", "dd.MM.uu");
+    
+    LocalDate ldToday = LocalDate.now();
+    Date dNow = DateUtil.localDate2Date(ldToday);
+    
+    Assert.assertEquals(dNow, DateUtil.startOfDay(dNow));
+    
+    DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+    String dNowFormatted = df.format(dNow);
+    
+    DateTimeFormatter dtf = DateTimeFormatter.ofPattern("uuuu-MM-dd");
+    String ldTodayFormatted = ldToday.format(dtf);
+    
+    Assert.assertEquals(ldTodayFormatted, dNowFormatted);
   }
 }

--- a/test/de/willuhn/jameica/util/DateUtilTest.java
+++ b/test/de/willuhn/jameica/util/DateUtilTest.java
@@ -242,4 +242,43 @@ public class DateUtilTest {
     
     Assert.assertEquals(ldTodayFormatted, dNowFormatted);
   }
+  
+  @Test
+  public void addMonthsMaintainingEndOfMonth() throws Exception {
+    DateUtil.setLocaleForTesting(Locale.GERMAN, "dd.MM.uuuu", "dd.MM.uu");
+    
+    LocalDate inputDate;
+    LocalDate expectedDate;
+    LocalDate modifiedDate;
+    
+    inputDate = LocalDate.of(2024, 4, 29);
+    expectedDate = LocalDate.of(2024, 5, 29);
+    modifiedDate = DateUtil.addMonthsMaintainingEndOfMonth(inputDate, 1);
+    Assert.assertEquals(expectedDate, modifiedDate);
+    
+    inputDate = LocalDate.of(2024, 4, 30);
+    expectedDate = LocalDate.of(2024, 5, 31);
+    modifiedDate = DateUtil.addMonthsMaintainingEndOfMonth(inputDate, 1);
+    Assert.assertEquals(expectedDate, modifiedDate);
+    
+    inputDate = LocalDate.of(2024, 5, 31);
+    expectedDate = LocalDate.of(2024, 4, 30);
+    modifiedDate = DateUtil.addMonthsMaintainingEndOfMonth(inputDate, -1);
+    Assert.assertEquals(expectedDate, modifiedDate);
+  }
+  
+  @Test
+  public void getDatePositions() throws Exception {
+    DateTimeFormatter dtfLong = DateTimeFormatter.ofPattern("dd---MM-----uuuu");
+    DateUtil.DatePositions positionsLong = DateUtil.getDatePositions(dtfLong);
+    DateUtil.DatePositions expectedPositions = new DateUtil.DatePositions(0, 2, 5, 2);
+    Assert.assertEquals(expectedPositions, positionsLong);
+    
+    
+    DateTimeFormatter dtfShort = DateTimeFormatter.ofPattern("dd---MM----uu");
+    DateUtil.DatePositions positionsShort = DateUtil.getDatePositions(dtfShort);
+    DateUtil.DatePositions expectedPositionsShort = new DateUtil.DatePositions(0, 2, 5, 2);
+    Assert.assertEquals(expectedPositionsShort, positionsShort);
+  }
+  
 }

--- a/test/de/willuhn/jameica/util/DateUtilTest.java
+++ b/test/de/willuhn/jameica/util/DateUtilTest.java
@@ -11,62 +11,187 @@
 package de.willuhn.jameica.util;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Locale;
+import java.util.Optional;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 
 public class DateUtilTest {
+  private String[][] validDates;
+  private String[] invalidDates;
 
-    @Test
-    public void convert2Date() throws Exception {
-        DateUtil.setLocaleForTesting(Locale.GERMAN);
-        LocalDate today = LocalDate.now();
-        int currentYear = today.getYear();
-        int currentMonth = today.getMonthValue(); // 1 = Jan
-        int currentDay = today.getDayOfMonth();
-        int lastDayOfFebruary = LocalDate.of(currentYear, 3, 1).minusDays(1).getDayOfMonth();
-        String[][] testStrings = {
-                // input, expected output
-                // === valid dates ===
-                {"01.02.2023", "01.02.2023"},
-                {"02032024", "02.03.2024"},
-                {"0304", String.format("03.04.%d", currentYear)},
-                {"04", String.format("04.%02d.%d", currentMonth, currentYear)},
-                {"5", String.format("05.%02d.%d", currentMonth, currentYear)},
-                {"6.7.2028", "06.07.2028"},
-                {"7.8.29", "07.08.2029"},
-                //{"8.9.", String.format("08.09.%d", currentYear)},
-                // special shortcuts
-                //{"h", String.format("%02d.%02d.%d", currentDay, currentMonth, currentYear)},
-                //{"g", },
-                //{"+60", },
-                //{"-60", },
-                //{"++15", },
-                //{"--15", },
-                //{"3002", String.format("%02d.02.%d", lastDayOfFebruary, currentYear)},
-                //{"30022024", "29.02.2024"},
-                //{"30.02.2024", "29.02.2024"},
-                // === invalid dates ===
-                {"0113", "0113"},
-                {"01132024", "01132024"},
-                //{"01.13.2024", "01.13.2024"},
-                {"01.012.2023", "01.012.2023"},
-                {"01.02.2023 13:37", "01.02.2023 13:37"},
-                {"01.02.2023 invalid", "01.02.2023 invalid"},
-                {"123", "123"},
-                {"0", "0"},
-                {"01023", "01023"},
-                {"09.10", "09.10"},
-                {"2023-02-01", "2023-02-01"},
-                {"invalid", "invalid"},
-        };
-        for (int i = 0; i < testStrings.length; i++) {
-            Assert.assertEquals(
-                    testStrings[i][1], // expected
-                    DateUtil.convert2Date(testStrings[i][0])  // actual
-            );
-        }
+  @Before
+  public void setUp() {
+    LocalDate today = LocalDate.now();
+    int currentYear = today.getYear();
+    int currentMonth = today.getMonthValue(); // 1 = Jan
+    int currentDay = today.getDayOfMonth();
+    int lastDayOfFebruary = LocalDate.of(currentYear, 3, 1).minusDays(1).getDayOfMonth();
+    LocalDate todayPlus60days = today.plusDays(60);
+    LocalDate todayMinus60days = today.minusDays(60);
+    LocalDate todayPlus15Months = today.plusMonths(15);
+    LocalDate todayMinus15Months = today.minusMonths(15);
+
+    validDates = new String[][]{
+        // input, expected output
+        // without delimiter
+        {"5", String.format("05.%02d.%d", currentMonth, currentYear)},
+        {"04", String.format("04.%02d.%d", currentMonth, currentYear)},
+        {"0304", String.format("03.04.%d", currentYear)},
+        {"02032024", "02.03.2024"},
+        // with delimiter
+        {"5.", String.format("05.%02d.%d", currentMonth, currentYear)},
+        {"05.", String.format("05.%02d.%d", currentMonth, currentYear)},
+        {"8.9.", String.format("08.09.%d", currentYear)},
+        {"08.9.", String.format("08.09.%d", currentYear)},
+        {"8.09.", String.format("08.09.%d", currentYear)},
+        {"7.8.29", "07.08.2029"},
+        {"07.8.29", "07.08.2029"},
+        {"7.08.29", "07.08.2029"},
+        {"7.8.2029", "07.08.2029"},
+        {"07.8.2029", "07.08.2029"},
+        {"7.08.2029", "07.08.2029"},
+        {"1/2/23", "01.02.2023"},
+        // offsets from today
+        {"h", String.format("%02d.%02d.%d", currentDay, currentMonth, currentYear)},
+        {"t", String.format("%02d.%02d.%d", currentDay, currentMonth, currentYear)},
+        {"-0", String.format("%02d.%02d.%d", currentDay, currentMonth, currentYear)},
+        {"+60", String.format("%02d.%02d.%d", todayPlus60days.getDayOfMonth(), todayPlus60days.getMonthValue(), todayPlus60days.getYear())},
+        {"-60", String.format("%02d.%02d.%d", todayMinus60days.getDayOfMonth(), todayMinus60days.getMonthValue(), todayMinus60days.getYear())},
+        {"++15", String.format("%02d.%02d.%d", todayPlus15Months.getDayOfMonth(), todayPlus15Months.getMonthValue(), todayPlus15Months.getYear())},
+        {"--15", String.format("%02d.%02d.%d", todayMinus15Months.getDayOfMonth(), todayMinus15Months.getMonthValue(), todayMinus15Months.getYear())},
+        {" --15", String.format("%02d.%02d.%d", todayMinus15Months.getDayOfMonth(), todayMinus15Months.getMonthValue(), todayMinus15Months.getYear())},
+        // auto-correct end of month
+        {"30022024", "29.02.2024"},
+        {"3002", String.format("%02d.02.%d", lastDayOfFebruary, currentYear)},
+        {"30.02.2024", "29.02.2024"},
+        // year in 2-digit notation: assume the last century if the year is more than 19 years from now
+        {String.format("01.01.%02d", currentYear - 80 - 1900), String.format("01.01.%02d", currentYear - 80)},
+        {String.format("01.01.%02d", currentYear - 81 - 1900), String.format("01.01.%02d", currentYear + 19)},
+        // special cases
+        {"01.012.2023", "01.12.2023"},
+    };
+    invalidDates = new String[]{
+        // don't auto-correct or roll over
+        "0113",
+        "01132024",
+        "01.13.2024",
+        // don't parse time
+        "01.02.2023 13:37",
+        // don't ignore suffixes, even if the date is parseable
+        "01.02.2023 invalid",
+        "012",
+        "123",
+        "01023",
+        // if a delimiter has been used for the day, the month also needs a delimiter
+        "09.10",
+        "9/10",
+        // invalid offsets
+        "1+3",
+        "01.02.2023+h",
+        "01.02.2023+4.5",
+        "01.02.2023+4,5",
+        "01.02.2023+4++",
+        "01.02.2023+++",
+        "01.02.2023+a++b",
+        "01.02.2023+++3",
+        "+",
+        "+ ++ ",
+        // offsets from date
+        "t-1",
+        "01.02.2023+4",
+        "01.02.2023++1",
+        "01.02.2023++1+4",
+        "01.02.2023+4++1",
+        "01.02.2023+4-4",
+        "30.02.2024+1",
+        "30.02.2024++1",
+        // offsets from date (end of month)
+        "30.04.2025++1",
+        "31.05.2025--1",
+        // special cases
+        "",
+        " ",
+        "0",
+        "00",
+        "2023-02-01",
+        "invalid",
+    };
+  }
+
+  @Test
+  public void convert2DateValid() throws Exception {
+    DateUtil.setLocaleForTesting(Locale.GERMAN);
+    String expected = "input | converted%n";
+    String actual = "input | converted%n";
+    for (int i = 0; i < validDates.length; i++) {
+      String input = validDates[i][0];
+      String result = DateUtil.convert2Date(input);
+      expected += String.format ("%s | %s%n", input, validDates[i][1]);
+      actual += String.format ("%s | %s%n", input, result);
     }
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void convert2DateInvalid() throws Exception {
+    String expected = "input | converted%n";
+    String actual = "input | converted%n";
+    for (int i = 0; i < invalidDates.length; i++) {
+      String input = invalidDates[i];
+      String converted = DateUtil.convert2Date(input);
+      expected += String.format ("%s | %s%n", input, input);
+      actual += String.format ("%s | %s%n", input, converted);
+    }
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void parseUserInputValid() throws Exception {
+    DateUtil.setLocaleForTesting(Locale.GERMAN);
+
+    DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("dd.MM.uuuu");
+    String expected = "input | parsed%n";
+    String actual = "input | parsed%n";
+    for (int i = 0; i < validDates.length; i++) {
+      String input = validDates[i][0];
+      expected += String.format ("%s | %s%n", input, validDates[i][1]);
+      String result = DateUtil.parseUserInput(input, null)
+          .map(date -> date.format(outputFormatter))
+          .orElse("null");
+      actual += String.format ("%s | %s%n", input, result);
+    }
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void parseUserInputInvalid() throws Exception {
+    DateUtil.setLocaleForTesting(Locale.GERMAN);
+    String expected = "input | parsingSucceeded%n";
+    String actual = "input | parsingSucceeded%n";
+    for (int i = 0; i < invalidDates.length; i++) {
+      String input = invalidDates[i];
+      Optional<LocalDate> parsed = DateUtil.parseUserInput(input, null);
+      expected += String.format("%s | %b%n", input, false);
+      actual += String.format("%s | %b%n", input, parsed.isPresent());
+    }
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void parseUserInputUsingCustomFormatter() throws Exception {
+    DateUtil.setLocaleForTesting(Locale.GERMAN);
+    String inputDate = "01---02//2023";
+
+    Optional<LocalDate> parsedDate = DateUtil.parseUserInput(inputDate, null);
+    Assert.assertTrue(parsedDate.isEmpty());
+
+    DateTimeFormatter customFormatter = DateTimeFormatter.ofPattern("dd---MM//uuuu");
+    parsedDate = DateUtil.parseUserInput(inputDate, customFormatter);
+    Assert.assertEquals(Optional.of(LocalDate.of(2023, 2, 1)), parsedDate);
+  }
 }


### PR DESCRIPTION
Moin moin,

ich habe mich ein bisschen um das Datums-Eingabefeld gekümmert. Eigentlich wollte ich nur einen kleinen Fehler beheben. Aber bei der Gelegenheit habe ich gleich noch ein paar andere Probleme behoben und neue Features eingebaut. Am besten schaust du dir die einzelnen Commit-Messages an, dann wird es übersichtlicher. Hier ein kurzer Überblick:

Behobene Probleme:
- Ein im Kurzformat eingegebenes Datum (z. B. "0203") wurde zwar richtig erkannt, aber nicht automatisch in die Langform formatiert (02.03.2024)
- Es wurden einige unsinnige Daten erkannt (z. B. "31.123.24" als 31.03.2034 oder "03.02.2024 test")
- inkonsistente Datumsangaben - insbesondere auf englisch war gar keine Datumseingabe über das Textfeld möglich
- Automatische Korrektur des Tages am Monatsende: aus dem 31.04. wird jetzt der 30.04. (und nicht wie bisher der 01.05.)

Neue Features:
- Tastenkombinationen: mit Alt + Bild hoch/runter kann der Tag hoch-/runtergezählt werden. Drückt man zusätzlich Shift, passiert das gleiche mit dem Monat
- zusätzlich zu den bisherigen Eingabehilfen gibt es jetzt "h" für heute sowie relative Tages-/Monatsangaben: z. B. "+3" für heute +3 Tage und "--2" für heute -2 Monate
- Damit User von den Eingabehilfen und Tastenkombinationen erfahren, hat das Datums-Eingabefeld jetzt einen Tooltip

Um von einem besseren Datums-Parsing und -Handling zu profitieren, wird intern die "neue" DateTime-Api (java.time.*) verwendet. Natürlich ist die Kompatibilität zu den anderen Programmteilen weiter gegeben - nach außen wird wie gehabt ein java.util.Date zurückgegeben.

Um das Verhalten vom DateUtil zu prüfen, habe ich Unit Tests hinzugefügt.

Viele Grüße
Florian