### PR TITLE
$XDG_CONFIG_HOME für .jameica.properties respektieren

### DIFF
--- a/src/de/willuhn/jameica/system/BootstrapSettings.java
+++ b/src/de/willuhn/jameica/system/BootstrapSettings.java
@@ -189,7 +189,15 @@ public class BootstrapSettings
   private static synchronized File getFile()
   {
     if (file == null)
-      file = new File(System.getProperty("user.home"),".jameica.properties");
+    {
+      String xdg = System.getenv("XDG_CONFIG_HOME");
+
+      if (xdg != null)
+        file = new File(xdg,"jameica.properties");
+      else
+        file = new File(System.getProperty("user.home"),".jameica.properties");
+    }
+
     return file;
   }
 }

--- a/src/de/willuhn/jameica/system/BootstrapSettings.java
+++ b/src/de/willuhn/jameica/system/BootstrapSettings.java
@@ -190,12 +190,11 @@ public class BootstrapSettings
   {
     if (file == null)
     {
+      file = new File(System.getProperty("user.home"),".jameica.properties");
       String xdg = System.getenv("XDG_CONFIG_HOME");
 
-      if (xdg != null)
+      if (!file.canRead() && xdg != null)
         file = new File(xdg,"jameica.properties");
-      else
-        file = new File(System.getProperty("user.home"),".jameica.properties");
     }
 
     return file;


### PR DESCRIPTION
Momentan ist es bereits möglich, den `.jameica`-Ordner an einem beliebigen Ort zu platzieren, die `.jameica.properties` muss aber immer im Benutzerverzeichnis liegen.

Für Linux-Systeme gibt es die [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/), die dem "Vollmüllen" dieses Ordners entgegenwirken soll, indem Umgebungsvariablen zu einheitlichen Pfaden gesetzt werden (hier relevant: `XDG_CONFIG_HOME` für Konfigurationsdateien).

Mit diesem Pull Request platziert Jameica die Konfigurationsdatei im mit `XDG_CONFIG_HOME` gesetzten Ordner. Das Benutzerverzeichnis bleibt als Fallback bestehen.