### PR TITLE
Jameica mit Java 17 bauen

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -7,9 +7,9 @@ define.encoding                 = ISO-8859-1
 
 # Auch wenn Jameica zum Start seit dem Nightly-Build vom 05.12.2024 Java 17 braucht (wegen SWT)
 # bleibt hier erstmal noch Java 11 stehen. Es gibt einige Plugins, die nur als Nightly-Build
-# verfügbar sind und auch gegen das Nightly-Build von Jameica compiliert werden, dennoch aber
-# auch auf dem aktuellen Jameica-Release lauffähig sein sollen
-define.java.version             = 11
+# verfÃ¼gbar sind und auch gegen das Nightly-Build von Jameica compiliert werden, dennoch aber
+# auch auf dem aktuellen Jameica-Release lauffÃ¤hig sein sollen
+define.java.version             = 17
 
 define.projectname              = jameica
 define.jarfilename              = ${define.projectname}.jar


### PR DESCRIPTION
JVerein baut nicht, wenn SWT mit Java 17 eingebunden wird, aber aber ant mit Java 11 baut.

Hier eine aktueller [build](https://github.com/openjverein/jverein/actions/runs/13260561199/job/37016002401#step:7:23) 
```
 compile:
    [mkdir] Created dir: /home/runner/work/jverein/jverein/jameica/releases/2.10.5-488/tmp/bin
    [javac] Compiling 389 source files to /home/runner/work/jverein/jverein/jameica/releases/2.10.5-488/tmp/bin
    [javac] /home/runner/work/jverein/jverein/jameica/src/de/willuhn/jameica/system/Settings.java:12: error: cannot access FontData
    [javac] import org.eclipse.swt.graphics.FontData;
    [javac]                                ^
    [javac]   bad class file: /home/runner/work/jverein/jverein/jameica/lib/swt/linux-arm64/swt.jar(/org/eclipse/swt/graphics/FontData.class)
    [javac]     class file has wrong version 61.0, should be 55.0
    [javac]     Please remove or make sure it appears in the correct subdirectory of the classpath.
```