### PR TITLE
AbstractDialog currentShell als parent

### DIFF
--- a/src/de/willuhn/jameica/gui/dialogs/AbstractDialog.java
+++ b/src/de/willuhn/jameica/gui/dialogs/AbstractDialog.java
@@ -210,7 +210,10 @@ public abstract class AbstractDialog<T>
         //              wir APPLICATION_MODAL, damit sichergestellt ist, dass
         //              der Login-Screen VOR dem Splash-Screen erscheint.
         //              Danach verwenden wir nur noch PRIMARY_MODAL
-        Shell rootShell = GUI.getShell();
+        Shell rootShell = getDisplay().getActiveShell();
+        if(rootShell == null) {
+          GUI.getShell();
+        }
         
         int modalType = SWT.PRIMARY_MODAL; // Default PRIMARY_MODAL
         if (rootShell.getData("systemshell") == null) // Ausser beim Bootvorgang - da ist das Property nicht gesetzt


### PR DESCRIPTION
In JVerein haben wir einen modeless Dialog erstellt. Dabei haben wir das Problem, dass wenn aus diesem Dialog ein weiterer Dialog aufgerufen wird, als parent immer das Hauptfenster verwendet wird. Das führt zT. zu seltsamem Verhalten.
Daher hier mein Vorschlag, immer die Aktive Shell als parent für neue Dialoge zu nehmen, damit ist das Problem gelöst.
Da, soweit ich überblicke, in hibiscus nirgends modless Dialoge verwendet werden, sollte das dort eigentlich keine Auswirkungen haben.