### PR TITLE
Symbolleiste hinzugefügt

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -17,6 +17,7 @@
       <item id="jameica.menu.bookmarks"         name="&amp;Lesezeichen..."             shortcut="CTRL+L"         icon="starred.png"             action="de.willuhn.jameica.gui.internal.action.BookmarkSearch" />
       <item id="jameica.menu.back"              name="&amp;Zurück"                     shortcut="ALT+ARROW_LEFT" icon="go-previous.png"         action="de.willuhn.jameica.gui.internal.action.Back" />
       <item id="jameica.menu.navigation.toggle" name="&amp;Navigation ein-/ausblenden" shortcut="ALT+N"          icon="view-fullscreen.png"     action="de.willuhn.jameica.gui.internal.action.NavigationToggle" />
+      <item id="jameica.menu.iconbar.toggle"    name="&amp;Symbolleiste ein-/ausblenden"                        icon="view-fullscreen.png"     action="de.willuhn.jameica.gui.internal.action.IconBarToggle" />
       <item name="-" />
       <item id="jameica.menu.settings"       name="&amp;Einstellungen"              shortcut="CTRL+E"         icon="document-properties.png" action="de.willuhn.jameica.gui.internal.action.Settings" />
       <item id="jameica.menu.backups"        name="&amp;Backups verwalten"                                    icon="document-save.png"       action="de.willuhn.jameica.gui.internal.action.Backup" />

--- a/src/de/willuhn/jameica/gui/AbstractItemXml.java
+++ b/src/de/willuhn/jameica/gui/AbstractItemXml.java
@@ -90,7 +90,7 @@ public abstract class AbstractItemXml implements Item
 
   	String s = path.getAttribute("action",null);
 
-  	if (s == null)
+  	if (s == null || s.trim().length() == 0)
   		return null;
 
 		try

--- a/src/de/willuhn/jameica/gui/GUI.java
+++ b/src/de/willuhn/jameica/gui/GUI.java
@@ -100,6 +100,7 @@ public class GUI implements ApplicationController
     private SashForm sash                = null;
     private Navigation navi              = null;
     private Menu menu                    = null;
+    private IconBar iconBar              = null;
     private View view                    = null;
     private StatusBar statusBar          = null;
     private SashForm left                = null;
@@ -200,6 +201,21 @@ public class GUI implements ApplicationController
       catch (Exception e)
       {
         Logger.error("error while loading menu, skipping",e);
+      }
+      //
+      ////////////////////////////////////////////////////////////////////////
+
+      ////////////////////////////////////////////////////////////////////////
+      // init IconBar
+      Logger.info("adding icon bar");
+      try
+      {
+        iconBar = new IconBar();
+        iconBar.paint(getShell());
+      }
+      catch (Exception e)
+      {
+        Logger.error("error while loading icon bar, skipping",e);
       }
       //
       ////////////////////////////////////////////////////////////////////////
@@ -310,8 +326,8 @@ public class GUI implements ApplicationController
         }
         try
         {
-          menu.add(mf.getMenu());
-          navi.add(mf.getNavigation());
+          menu.add(mf.getMenu(),mf.getName());
+          navi.add(mf.getNavigation(),mf.getName());
         }
         catch (Throwable t)
         {
@@ -320,6 +336,9 @@ public class GUI implements ApplicationController
       }
       //
       ////////////////////////////////////////////////////////////////////////
+
+      if (iconBar != null)
+        iconBar.redraw();
 
       ////////////////////////////////////////////////////////////////////////
       // launch gui
@@ -507,6 +526,15 @@ public class GUI implements ApplicationController
   public static Menu getMenu()
   {
     return gui.menu;
+  }
+
+  /**
+   * Liefert die Symbolleiste.
+   * @return Symbolleiste.
+   */
+  public static IconBar getIconBar()
+  {
+    return gui.iconBar;
   }
 
   /**

--- a/src/de/willuhn/jameica/gui/IconBar.java
+++ b/src/de/willuhn/jameica/gui/IconBar.java
@@ -1,0 +1,774 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2026 Olaf Willuhn
+ * All rights reserved.
+ * 
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details. 
+ *
+ **********************************************************************/
+package de.willuhn.jameica.gui;
+
+import java.io.File;
+import java.io.InputStream;
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.DisposeEvent;
+import org.eclipse.swt.events.DisposeListener;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.ToolBar;
+import org.eclipse.swt.widgets.ToolItem;
+
+import de.willuhn.datasource.GenericIterator;
+import de.willuhn.datasource.GenericObject;
+import de.willuhn.datasource.GenericObjectNode;
+import de.willuhn.datasource.pseudo.PseudoIterator;
+import de.willuhn.io.IOUtil;
+import de.willuhn.jameica.bookmark.Bookmark;
+import de.willuhn.jameica.bookmark.BookmarkService;
+import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.dialogs.SearchableListDialog;
+import de.willuhn.jameica.gui.internal.action.BookmarkOpen;
+import de.willuhn.jameica.gui.util.SWTUtil;
+import de.willuhn.jameica.messaging.Message;
+import de.willuhn.jameica.messaging.MessageConsumer;
+import de.willuhn.jameica.messaging.QueryMessage;
+import de.willuhn.jameica.messaging.StatusBarMessage;
+import de.willuhn.jameica.services.BeanService;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * Symbolleiste unterhalb des Hauptmenus.
+ */
+public class IconBar implements Part
+{
+  private Composite parent;
+  private Composite container;
+  private ToolBar toolBar;
+  private List<Image> images = new ArrayList<Image>();
+  private IconBarEntry contextEntry = null;
+  private MessageConsumer bookmarkDeletedConsumer = null;
+
+  /**
+   * @see de.willuhn.jameica.gui.Part#paint(org.eclipse.swt.widgets.Composite)
+   */
+  public void paint(Composite parent) throws RemoteException
+  {
+    this.parent = parent;
+    this.container = new Composite(parent,SWT.NONE);
+    this.container.setLayout(de.willuhn.jameica.gui.util.SWTUtil.createGrid(1,true));
+    this.container.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+    registerBookmarkDeletedConsumer();
+    this.container.addDisposeListener(new DisposeListener()
+    {
+      public void widgetDisposed(DisposeEvent e)
+      {
+        unregisterBookmarkDeletedConsumer();
+      }
+    });
+    redraw();
+  }
+
+  /**
+   * Zeichnet die Leiste neu.
+   */
+  public void redraw()
+  {
+    if (this.container == null || this.container.isDisposed())
+      return;
+
+    disposeToolBar();
+
+    GridData data = (GridData) this.container.getLayoutData();
+    if (!IconBarSettings.isVisible())
+    {
+      data.exclude = true;
+      data.heightHint = 0;
+      this.container.setVisible(false);
+      this.parent.layout(true,true);
+      return;
+    }
+
+    int height = IconBarSettings.getIconSize() + 8;
+    data.exclude = false;
+    data.heightHint = height;
+    this.container.setVisible(true);
+    this.toolBar = new ToolBar(this.container,SWT.FLAT);
+    createContextMenu(this.container);
+    createContextMenu(this.toolBar);
+    GridData toolBarData = new GridData(GridData.FILL_HORIZONTAL);
+    toolBarData.heightHint = height;
+    this.toolBar.setLayoutData(toolBarData);
+
+    List<IconBarEntry> entries = IconBarSettings.getEntries();
+    for (IconBarEntry entry:entries)
+      add(entry);
+
+    this.toolBar.addDisposeListener(new DisposeListener()
+    {
+      public void widgetDisposed(DisposeEvent e)
+      {
+        disposeImages();
+      }
+    });
+
+    this.container.layout(true,true);
+    this.parent.layout(true,true);
+  }
+
+  /**
+   * Registriert den Consumer fuer geloeschte Lesezeichen.
+   */
+  private void registerBookmarkDeletedConsumer()
+  {
+    if (this.bookmarkDeletedConsumer != null)
+      return;
+
+    this.bookmarkDeletedConsumer = new BookmarkDeletedConsumer();
+    Application.getMessagingFactory().getMessagingQueue(BookmarkService.QUEUE_DELETED).registerMessageConsumer(this.bookmarkDeletedConsumer);
+  }
+
+  /**
+   * Meldet den Consumer fuer geloeschte Lesezeichen ab.
+   */
+  private void unregisterBookmarkDeletedConsumer()
+  {
+    if (this.bookmarkDeletedConsumer == null)
+      return;
+
+    Application.getMessagingFactory().getMessagingQueue(BookmarkService.QUEUE_DELETED).unRegisterMessageConsumer(this.bookmarkDeletedConsumer);
+    this.bookmarkDeletedConsumer = null;
+  }
+
+  /**
+   * Erzeugt das Kontextmenu der Symbolleiste.
+   * @param control Control.
+   */
+  private void createContextMenu(org.eclipse.swt.widgets.Control control)
+  {
+    if (control == null || control.isDisposed())
+      return;
+
+    if (control instanceof ToolBar)
+    {
+      final ToolBar bar = (ToolBar) control;
+      bar.addListener(SWT.MenuDetect,event -> {
+        ToolItem item = bar.getItem(bar.toControl(event.x,event.y));
+        Object data = item != null ? item.getData("entry") : null;
+        contextEntry = data instanceof IconBarEntry ? (IconBarEntry) data : null;
+      });
+    }
+    else
+    {
+      control.addListener(SWT.MenuDetect,event -> contextEntry = null);
+    }
+
+    final org.eclipse.swt.widgets.Menu menu = new org.eclipse.swt.widgets.Menu(control);
+    control.setMenu(menu);
+
+    org.eclipse.swt.widgets.MenuItem add = new org.eclipse.swt.widgets.MenuItem(menu,SWT.PUSH);
+    add.setText(Application.getI18n().tr("Hinzuf\u00fcgen"));
+    add.setImage(SWTUtil.getImage("list-add.png"));
+    add.addListener(SWT.Selection,event -> openAddDialog());
+
+    final org.eclipse.swt.widgets.MenuItem remove = new org.eclipse.swt.widgets.MenuItem(menu,SWT.PUSH);
+    remove.setText(Application.getI18n().tr("Entfernen"));
+    remove.setImage(SWTUtil.getImage("list-remove.png"));
+    remove.addListener(SWT.Selection,event -> removeContextEntry());
+
+    new org.eclipse.swt.widgets.MenuItem(menu,SWT.SEPARATOR);
+
+    org.eclipse.swt.widgets.MenuItem settings = new org.eclipse.swt.widgets.MenuItem(menu,SWT.PUSH);
+    settings.setText(Application.getI18n().tr("Anpassen..."));
+    settings.setImage(SWTUtil.getImage("document-properties.png"));
+    settings.addListener(SWT.Selection,event -> openSettings());
+
+    menu.addListener(SWT.Show,event -> remove.setEnabled(contextEntry != null));
+  }
+
+  /**
+   * Oeffnet den Hinzufuegen-Dialog fuer die Symbolleiste.
+   */
+  private void openAddDialog()
+  {
+    try
+    {
+      List<IconBarEntry> items = new ArrayList<IconBarEntry>();
+      if (GUI.getNavigation() != null)
+        items.addAll(GUI.getNavigation().getActionItems());
+      if (GUI.getMenu() != null)
+        items.addAll(GUI.getMenu().getActionItems());
+      items.addAll(getBookmarkItems());
+
+      SearchableListDialog dialog = new SearchableListDialog(items,AbstractDialog.POSITION_CENTER);
+      dialog.setTitle(Application.getI18n().tr("Eintrag w\u00e4hlen"));
+      dialog.addColumn(Application.getI18n().tr("Bezeichnung"),"name");
+      dialog.addColumn(Application.getI18n().tr("Quelle"),"source");
+      dialog.addColumn(Application.getI18n().tr("Plugin"),"plugin");
+      dialog.addColumn(Application.getI18n().tr("ID"),"itemId");
+      IconBarEntry entry = (IconBarEntry) dialog.open();
+      if (entry == null)
+        return;
+
+      IconBarSettings.add(entry);
+      IconBarSettings.setVisible(true);
+      redraw();
+      Application.getMessagingFactory().sendMessage(new StatusBarMessage(Application.getI18n().tr("Eintrag zur Symbolleiste hinzugef\u00fcgt"),StatusBarMessage.TYPE_SUCCESS));
+    }
+    catch (OperationCanceledException oce)
+    {
+      Logger.debug("operation cancelled");
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to add icon bar entry",e);
+      Application.getMessagingFactory().sendMessage(new StatusBarMessage(Application.getI18n().tr("Fehler beim Hinzuf\u00fcgen zur Symbolleiste"),StatusBarMessage.TYPE_ERROR));
+    }
+  }
+
+  /**
+   * Entfernt den per Rechtsklick gewaehlten Eintrag.
+   */
+  private void removeContextEntry()
+  {
+    if (this.contextEntry == null)
+      return;
+
+    IconBarSettings.remove(this.contextEntry);
+    this.contextEntry = null;
+    redraw();
+  }
+
+  /**
+   * Oeffnet die Einstellungen im Tab Look and Feel.
+   */
+  private void openSettings()
+  {
+    try
+    {
+      new de.willuhn.jameica.gui.internal.action.Settings().handleAction(Application.getI18n().tr("Look and Feel"));
+    }
+    catch (ApplicationException ae)
+    {
+      Application.getMessagingFactory().sendMessage(new StatusBarMessage(ae.getMessage(),StatusBarMessage.TYPE_ERROR));
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to open icon bar settings",e);
+      Application.getMessagingFactory().sendMessage(new StatusBarMessage(Application.getI18n().tr("Fehler beim Öffnen der Einstellungen"),StatusBarMessage.TYPE_ERROR));
+    }
+  }
+
+  /**
+   * Fuegt einen Eintrag hinzu.
+   * @param entry Eintrag.
+   */
+  private void add(final IconBarEntry entry)
+  {
+    try
+    {
+      if (IconBarEntry.TYPE_SPACER.equals(entry.getType()))
+      {
+        addSpacer();
+        return;
+      }
+
+      final Item item = resolve(entry);
+      if (item == null)
+      {
+        Logger.warn("icon bar item not found: " + entry.getType() + "/" + entry.getItemId());
+        return;
+      }
+
+      final Action action = item.getAction();
+      if (action == null)
+        return;
+
+      String name = StringUtils.trimToNull(item.getName());
+      if (name == null)
+        name = entry.getName();
+      entry.setName(name);
+
+      ToolItem toolItem = new ToolItem(this.toolBar,SWT.PUSH);
+      toolItem.setData("entry",entry);
+      toolItem.setToolTipText(name);
+      toolItem.setEnabled(item.isEnabled());
+
+      Image image = getImage(entry,item);
+      if (isUsableImage(image))
+      {
+        toolItem.setImage(image);
+      }
+      else
+      {
+        toolItem.setText(getReplacementText(name));
+      }
+
+      toolItem.addListener(SWT.Selection, event -> execute(action,event));
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to add icon bar entry",e);
+    }
+  }
+
+  /**
+   * Fuegt einen Abstandshalter hinzu.
+   */
+  private void addSpacer()
+  {
+    ToolItem toolItem = new ToolItem(this.toolBar,SWT.SEPARATOR);
+    toolItem.setWidth(IconBarSettings.getIconSize() + 8);
+  }
+
+  /**
+   * Fuehrt die Action aus.
+   * @param action Action.
+   * @param event SWT-Event.
+   */
+  private void execute(final Action action, final Event event)
+  {
+    try
+    {
+      action.handleAction(event);
+    }
+    catch (OperationCanceledException oce)
+    {
+      Logger.debug("operation cancelled");
+    }
+    catch (ApplicationException ae)
+    {
+      Application.getMessagingFactory().sendMessage(new StatusBarMessage(ae.getMessage(),StatusBarMessage.TYPE_ERROR));
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to execute icon bar action",e);
+      Application.getMessagingFactory().sendMessage(new StatusBarMessage(Application.getI18n().tr("Fehler beim Ausf\u00fchren des Menu-Eintrages"),StatusBarMessage.TYPE_ERROR));
+    }
+  }
+
+  /**
+   * Liefert das Image fuer den Eintrag.
+   * @param entry Eintrag.
+   * @param item Quell-Item.
+   * @return Image.
+   * @throws RemoteException
+   */
+  private Image getImage(IconBarEntry entry, Item item) throws RemoteException
+  {
+    String override = StringUtils.trimToNull(entry.getIcon());
+    Image image = override != null && hasImage(override) ? SWTUtil.getImage(override) : getDefaultImage(item);
+    return scale(image,IconBarSettings.getIconSize());
+  }
+
+  /**
+   * Prueft, ob ein Bild als Icon verwendbar ist.
+   * @param image Bild.
+   * @return true, wenn es verwendbar ist.
+   */
+  private boolean isUsableImage(Image image)
+  {
+    if (image == null || image.isDisposed())
+      return false;
+
+    Rectangle bounds = image.getBounds();
+    return bounds.width > 1 && bounds.height > 1;
+  }
+
+  /**
+   * Liefert den Text-Ersatz fuer fehlende Icons.
+   * @param name Beschreibung.
+   * @return maximal drei Zeichen.
+   */
+  private String getReplacementText(String name)
+  {
+    name = StringUtils.trimToEmpty(name);
+    if (name.length() <= 3)
+      return name;
+    return name.substring(0,3);
+  }
+
+  /**
+   * Prueft, ob das Icon existiert.
+   * @param name Dateiname.
+   * @return true, wenn das Icon existiert.
+   */
+  private boolean hasImage(String name)
+  {
+    InputStream is = null;
+    try
+    {
+      is = Application.getClassLoader().getResourceAsStream("img/" + name);
+      if (is != null)
+        return true;
+
+      File file = new File(new File(Application.getConfig().getWorkDir(),"img"),name);
+      return file.isFile() && file.canRead();
+    }
+    finally
+    {
+      IOUtil.close(is);
+    }
+  }
+
+  /**
+   * Liefert das Default-Icon des Quell-Items.
+   * @param item Quell-Item.
+   * @return Image.
+   * @throws RemoteException
+   */
+  private Image getDefaultImage(Item item) throws RemoteException
+  {
+    if (item instanceof NavigationItem)
+      return ((NavigationItem)item).getIconClose();
+    if (item instanceof MenuItem)
+      return ((MenuItem)item).getIcon();
+    if (item instanceof BookmarkItem)
+      return SWTUtil.getImage(BookmarkItem.ICON);
+    return null;
+  }
+
+  /**
+   * Skaliert ein Image auf die konfigurierte Groesse.
+   * @param image Image.
+   * @param size Zielgroesse.
+   * @return skaliertes Image.
+   */
+  private Image scale(Image image, int size)
+  {
+    if (image == null || image.isDisposed())
+      return null;
+
+    Rectangle bounds = image.getBounds();
+    if (bounds.width <= 1 || bounds.height <= 1)
+      return null;
+
+    if (bounds.width == size && bounds.height == size)
+      return image;
+
+    ImageData data = image.getImageData().scaledTo(size,size);
+    Image scaled = new Image(GUI.getDisplay(),data);
+    this.images.add(scaled);
+    return scaled;
+  }
+
+  /**
+   * Loest einen gespeicherten Eintrag auf.
+   * @param entry Eintrag.
+   * @return Item oder NULL.
+   */
+  public static Item resolve(IconBarEntry entry)
+  {
+    if (entry == null)
+      return null;
+
+    if (IconBarEntry.TYPE_NAVIGATION.equals(entry.getType()))
+      return GUI.getNavigation() != null ? GUI.getNavigation().getItem(entry.getItemId()) : null;
+
+    if (IconBarEntry.TYPE_MENU.equals(entry.getType()))
+      return GUI.getMenu() != null ? GUI.getMenu().getItem(entry.getItemId()) : null;
+
+    if (IconBarEntry.TYPE_BOOKMARK.equals(entry.getType()))
+      return resolveBookmark(entry.getItemId());
+
+    return null;
+  }
+
+  /**
+   * Entfernt ein geloeschtes Lesezeichen aus der Symbolleiste.
+   * @param bookmark geloeschtes Lesezeichen.
+   */
+  private void removeBookmark(Bookmark bookmark)
+  {
+    String id = getBookmarkId(bookmark);
+    if (!IconBarSettings.contains(IconBarEntry.TYPE_BOOKMARK,id))
+      return;
+
+    IconBarSettings.remove(new IconBarEntry(IconBarEntry.TYPE_BOOKMARK,id,"",null));
+    GUI.getDisplay().asyncExec(new Runnable()
+    {
+      public void run()
+      {
+        redraw();
+      }
+    });
+  }
+
+  /**
+   * Message-Consumer fuer geloeschte Lesezeichen.
+   */
+  private class BookmarkDeletedConsumer implements MessageConsumer
+  {
+    /**
+     * @see de.willuhn.jameica.messaging.MessageConsumer#autoRegister()
+     */
+    public boolean autoRegister()
+    {
+      return false;
+    }
+
+    /**
+     * @see de.willuhn.jameica.messaging.MessageConsumer#getExpectedMessageTypes()
+     */
+    public Class[] getExpectedMessageTypes()
+    {
+      return new Class[]{QueryMessage.class};
+    }
+
+    /**
+     * @see de.willuhn.jameica.messaging.MessageConsumer#handleMessage(de.willuhn.jameica.messaging.Message)
+     */
+    public void handleMessage(Message message) throws Exception
+    {
+      if (!(message instanceof QueryMessage))
+        return;
+
+      Object data = ((QueryMessage)message).getData();
+      if (data instanceof Bookmark)
+        removeBookmark((Bookmark)data);
+    }
+  }
+
+  /**
+   * Liefert alle Lesezeichen als Symbolleisten-Eintraege.
+   * @return Lesezeichen-Eintraege.
+   */
+  public static List<IconBarEntry> getBookmarkItems()
+  {
+    List<IconBarEntry> result = new ArrayList<IconBarEntry>();
+    try
+    {
+      for (Bookmark bookmark:getBookmarkService().getBookmarks())
+      {
+        IconBarEntry entry = new IconBarEntry(IconBarEntry.TYPE_BOOKMARK,getBookmarkId(bookmark),getBookmarkName(bookmark),null);
+        entry.setPlugin("Jameica");
+        result.add(entry);
+      }
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to load bookmarks for icon bar",e);
+    }
+    return result;
+  }
+
+  /**
+   * Loest ein Lesezeichen auf.
+   * @param id Lesezeichen-ID.
+   * @return Item oder NULL.
+   */
+  private static Item resolveBookmark(String id)
+  {
+    try
+    {
+      Bookmark bookmark = findBookmark(id);
+      return bookmark != null ? new BookmarkItem(bookmark) : null;
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to resolve bookmark",e);
+      return null;
+    }
+  }
+
+  /**
+   * Findet ein Lesezeichen anhand der Symbolleisten-ID.
+   * @param id Lesezeichen-ID.
+   * @return Lesezeichen oder NULL.
+   * @throws ApplicationException
+   */
+  private static Bookmark findBookmark(String id) throws ApplicationException
+  {
+    if (id == null)
+      return null;
+
+    for (Bookmark bookmark:getBookmarkService().getBookmarks())
+    {
+      if (id.equals(getBookmarkId(bookmark)))
+        return bookmark;
+    }
+    return null;
+  }
+
+  /**
+   * Liefert den Lesezeichen-Service.
+   * @return Service.
+   */
+  private static BookmarkService getBookmarkService()
+  {
+    BeanService service = Application.getBootLoader().getBootable(BeanService.class);
+    return service.get(BookmarkService.class);
+  }
+
+  /**
+   * Liefert eine stabile ID fuer ein Lesezeichen.
+   * @param bookmark Lesezeichen.
+   * @return ID.
+   */
+  private static String getBookmarkId(Bookmark bookmark)
+  {
+    if (bookmark == null)
+      return "";
+
+    Date created = bookmark.getCreated();
+    long time = created != null ? created.getTime() : 0L;
+    return time + ":" + StringUtils.trimToEmpty(bookmark.getView()) + ":" + StringUtils.trimToEmpty(bookmark.getTitle());
+  }
+
+  /**
+   * Liefert den Anzeigenamen eines Lesezeichens.
+   * @param bookmark Lesezeichen.
+   * @return Anzeigename.
+   */
+  private static String getBookmarkName(Bookmark bookmark)
+  {
+    if (bookmark == null)
+      return Application.getI18n().tr("Lesezeichen");
+
+    String name = StringUtils.trimToNull(bookmark.getTitle());
+    if (name != null)
+      return name;
+    name = StringUtils.trimToNull(bookmark.getComment());
+    return name != null ? name : Application.getI18n().tr("Lesezeichen");
+  }
+
+  /**
+   * Item-Wrapper fuer Lesezeichen.
+   */
+  private static class BookmarkItem implements Item
+  {
+    private static final String ICON = "starred.png";
+    private Bookmark bookmark;
+
+    private BookmarkItem(Bookmark bookmark)
+    {
+      this.bookmark = bookmark;
+    }
+
+    public String getName() throws RemoteException
+    {
+      return getBookmarkName(this.bookmark);
+    }
+
+    public Action getAction() throws RemoteException
+    {
+      final Bookmark bookmark = this.bookmark;
+      return new Action()
+      {
+        public void handleAction(Object context) throws ApplicationException
+        {
+          new BookmarkOpen().handleAction(bookmark);
+        }
+      };
+    }
+
+    public void addChild(Item i) throws RemoteException
+    {
+    }
+
+    public boolean isEnabled() throws RemoteException
+    {
+      return this.bookmark != null;
+    }
+
+    public void setEnabled(boolean enabled, boolean recursive) throws RemoteException
+    {
+    }
+
+    public GenericIterator getChildren() throws RemoteException
+    {
+      return PseudoIterator.fromArray(new Item[0]);
+    }
+
+    public boolean hasChild(GenericObjectNode object) throws RemoteException
+    {
+      return false;
+    }
+
+    public GenericObjectNode getParent() throws RemoteException
+    {
+      return null;
+    }
+
+    public GenericIterator getPossibleParents() throws RemoteException
+    {
+      return PseudoIterator.fromArray(new Item[0]);
+    }
+
+    public GenericIterator getPath() throws RemoteException
+    {
+      return PseudoIterator.fromArray(new Item[0]);
+    }
+
+    public Object getAttribute(String name) throws RemoteException
+    {
+      if ("name".equals(name))
+        return getName();
+      if ("type".equals(name))
+        return IconBarEntry.TYPE_BOOKMARK;
+      return null;
+    }
+
+    public String[] getAttributeNames() throws RemoteException
+    {
+      return new String[] {"name","type"};
+    }
+
+    public String getID() throws RemoteException
+    {
+      return getBookmarkId(this.bookmark);
+    }
+
+    public String getExtendableID()
+    {
+      return null;
+    }
+
+    public String getPrimaryAttribute() throws RemoteException
+    {
+      return "name";
+    }
+
+    public boolean equals(GenericObject other) throws RemoteException
+    {
+      return other != null && getID().equals(other.getID());
+    }
+  }
+
+  /**
+   * Entsorgt die Toolbar.
+   */
+  private void disposeToolBar()
+  {
+    if (this.toolBar != null && !this.toolBar.isDisposed())
+      this.toolBar.dispose();
+    this.toolBar = null;
+    disposeImages();
+  }
+
+  /**
+   * Entsorgt skalierte Images.
+   */
+  private void disposeImages()
+  {
+    for (Image image:this.images)
+    {
+      if (image != null && !image.isDisposed())
+        image.dispose();
+    }
+    this.images.clear();
+  }
+}

--- a/src/de/willuhn/jameica/gui/IconBarEntry.java
+++ b/src/de/willuhn/jameica/gui/IconBarEntry.java
@@ -1,0 +1,205 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2026 Olaf Willuhn
+ * All rights reserved.
+ * 
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details. 
+ *
+ **********************************************************************/
+package de.willuhn.jameica.gui;
+
+import java.rmi.RemoteException;
+import java.util.UUID;
+
+import org.apache.commons.lang.StringUtils;
+
+import de.willuhn.datasource.GenericObject;
+
+/**
+ * Ein konfigurierter Eintrag in der Symbolleiste.
+ */
+public class IconBarEntry implements GenericObject
+{
+  public static final String TYPE_NAVIGATION = "navigation";
+  public static final String TYPE_MENU       = "menu";
+  public static final String TYPE_BOOKMARK   = "bookmark";
+  public static final String TYPE_SPACER     = "spacer";
+
+  private String type;
+  private String itemId;
+  private String name;
+  private String icon;
+  private String plugin;
+
+  /**
+   * ct.
+   * @param type Typ des Quell-Eintrags.
+   * @param itemId ID des Quell-Eintrags.
+   * @param name Anzeigename.
+   * @param icon optionaler Icon-Override.
+   */
+  public IconBarEntry(String type, String itemId, String name, String icon)
+  {
+    this.type   = type;
+    this.itemId = itemId;
+    this.name   = name;
+    this.icon   = icon;
+  }
+
+  /**
+   * Erzeugt einen Abstandshalter.
+   * @return Abstandshalter.
+   */
+  public static IconBarEntry createSpacer()
+  {
+    return new IconBarEntry(TYPE_SPACER,UUID.randomUUID().toString(),"Abstand",null);
+  }
+
+  /**
+   * Liefert den Typ.
+   * @return Typ.
+   */
+  public String getType()
+  {
+    return this.type;
+  }
+
+  /**
+   * Liefert die Item-ID.
+   * @return Item-ID.
+   */
+  public String getItemId()
+  {
+    return this.itemId;
+  }
+
+  /**
+   * Liefert den Namen.
+   * @return Name.
+   */
+  public String getName()
+  {
+    return cleanupName(this.name);
+  }
+
+  /**
+   * Speichert den Namen.
+   * @param name Name.
+   */
+  public void setName(String name)
+  {
+    this.name = cleanupName(name);
+  }
+
+  /**
+   * Entfernt Mnemonic-Marker aus UI-Bezeichnungen.
+   * @param name Bezeichnung.
+   * @return bereinigte Bezeichnung.
+   */
+  private static String cleanupName(String name)
+  {
+    return StringUtils.trimToNull(name) == null ? name : name.replace("&&","&").replace("&","");
+  }
+
+  /**
+   * Liefert den Icon-Override.
+   * @return Icon-Override oder NULL.
+   */
+  public String getIcon()
+  {
+    return this.icon;
+  }
+
+  /**
+   * Speichert den Icon-Override.
+   * @param icon Icon-Override oder NULL.
+   */
+  public void setIcon(String icon)
+  {
+    this.icon = icon;
+  }
+
+  /**
+   * Liefert die Quelle als Text.
+   * @return Quelle.
+   */
+  public String getSource()
+  {
+    if (TYPE_SPACER.equals(this.type))
+      return "Abstand";
+    if (TYPE_BOOKMARK.equals(this.type))
+      return "Lesezeichen";
+    if (TYPE_MENU.equals(this.type))
+      return "Menü";
+    return "Navigation";
+  }
+
+  /**
+   * Liefert den Namen des Plugins.
+   * @return Plugin-Name.
+   */
+  public String getPlugin()
+  {
+    return this.plugin;
+  }
+
+  /**
+   * Speichert den Namen des Plugins.
+   * @param plugin Plugin-Name.
+   */
+  public void setPlugin(String plugin)
+  {
+    this.plugin = plugin;
+  }
+
+  /**
+   * @see de.willuhn.datasource.GenericObject#getAttribute(java.lang.String)
+   */
+  public Object getAttribute(String name) throws RemoteException
+  {
+    if ("name".equals(name))
+      return getName();
+    if ("source".equals(name))
+      return getSource();
+    if ("plugin".equals(name))
+      return getPlugin();
+    if ("icon".equals(name))
+      return getIcon();
+    if ("itemId".equals(name))
+      return TYPE_SPACER.equals(this.type) ? "" : getItemId();
+    return null;
+  }
+
+  /**
+   * @see de.willuhn.datasource.GenericObject#getAttributeNames()
+   */
+  public String[] getAttributeNames() throws RemoteException
+  {
+    return new String[] {"name","source","plugin","icon","itemId"};
+  }
+
+  /**
+   * @see de.willuhn.datasource.GenericObject#getID()
+   */
+  public String getID() throws RemoteException
+  {
+    return this.type + ":" + this.itemId;
+  }
+
+  /**
+   * @see de.willuhn.datasource.GenericObject#getPrimaryAttribute()
+   */
+  public String getPrimaryAttribute() throws RemoteException
+  {
+    return "name";
+  }
+
+  /**
+   * @see de.willuhn.datasource.GenericObject#equals(de.willuhn.datasource.GenericObject)
+   */
+  public boolean equals(GenericObject other) throws RemoteException
+  {
+    return other != null && getID().equals(other.getID());
+  }
+}

--- a/src/de/willuhn/jameica/gui/IconBarSettings.java
+++ b/src/de/willuhn/jameica/gui/IconBarSettings.java
@@ -1,0 +1,257 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2026 Olaf Willuhn
+ * All rights reserved.
+ * 
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details. 
+ *
+ **********************************************************************/
+package de.willuhn.jameica.gui;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+
+import de.willuhn.jameica.system.Settings;
+import de.willuhn.logging.Logger;
+
+/**
+ * Persistenz fuer die Symbolleiste.
+ */
+public final class IconBarSettings
+{
+  private static final Settings SETTINGS = new Settings(IconBarSettings.class);
+
+  private static final String KEY_VISIBLE = "visible";
+  private static final String KEY_SIZE    = "size";
+  private static final String KEY_COUNT   = "entry.count";
+  private static final String KEY_DEFAULT = "defaults.created";
+
+  public static final String SIZE_SMALL  = "small";
+  public static final String SIZE_MEDIUM = "medium";
+  public static final String SIZE_LARGE  = "large";
+
+  private IconBarSettings()
+  {
+  }
+
+  /**
+   * Prueft, ob die Symbolleiste sichtbar ist.
+   * @return true, wenn sie sichtbar ist.
+   */
+  public static boolean isVisible()
+  {
+    return SETTINGS.getBoolean(KEY_VISIBLE,true);
+  }
+
+  /**
+   * Speichert die Sichtbarkeit.
+   * @param visible Sichtbarkeit.
+   */
+  public static void setVisible(boolean visible)
+  {
+    SETTINGS.setAttribute(KEY_VISIBLE,visible);
+  }
+
+  /**
+   * Schaltet die Sichtbarkeit um.
+   * @return neuer Zustand.
+   */
+  public static boolean toggleVisible()
+  {
+    boolean visible = !isVisible();
+    setVisible(visible);
+    return visible;
+  }
+
+  /**
+   * Liefert die konfigurierte Groesse.
+   * @return Groesse.
+   */
+  public static String getSize()
+  {
+    String size = SETTINGS.getString(KEY_SIZE,SIZE_MEDIUM);
+    if (!SIZE_SMALL.equals(size) && !SIZE_MEDIUM.equals(size) && !SIZE_LARGE.equals(size))
+      return SIZE_MEDIUM;
+    return size;
+  }
+
+  /**
+   * Speichert die konfigurierte Groesse.
+   * @param size Groesse.
+   */
+  public static void setSize(String size)
+  {
+    if (size == null)
+      size = SIZE_MEDIUM;
+    SETTINGS.setAttribute(KEY_SIZE,size);
+  }
+
+  /**
+   * Liefert die Icon-Groesse in Pixeln.
+   * @return Groesse in Pixeln.
+   */
+  public static int getIconSize()
+  {
+    String size = getSize();
+    if (SIZE_SMALL.equals(size))
+      return 16;
+    if (SIZE_LARGE.equals(size))
+      return 32;
+    return 24;
+  }
+
+  /**
+   * Liefert alle Eintraege.
+   * @return Eintraege.
+   */
+  public static List<IconBarEntry> getEntries()
+  {
+    ensureDefaults();
+
+    List<IconBarEntry> entries = new ArrayList<IconBarEntry>();
+    int count = SETTINGS.getInt(KEY_COUNT,0);
+    for (int i=0;i<count;++i)
+    {
+      String prefix = "entry." + i + ".";
+      String type = StringUtils.trimToNull(SETTINGS.getString(prefix + "type",null));
+      String id   = StringUtils.trimToNull(SETTINGS.getString(prefix + "id",null));
+      if (type == null || id == null)
+        continue;
+
+      String name = SETTINGS.getString(prefix + "name",id);
+      String icon = StringUtils.trimToNull(SETTINGS.getString(prefix + "icon",null));
+      entries.add(new IconBarEntry(type,id,name,icon));
+    }
+    return entries;
+  }
+
+  /**
+   * Speichert die Eintraege.
+   * @param entries Eintraege.
+   */
+  public static void setEntries(List<IconBarEntry> entries)
+  {
+    int oldCount = SETTINGS.getInt(KEY_COUNT,0);
+    for (int i=0;i<oldCount;++i)
+      clear(i);
+
+    int count = entries != null ? entries.size() : 0;
+    SETTINGS.setAttribute(KEY_COUNT,count);
+    for (int i=0;i<count;++i)
+    {
+      IconBarEntry entry = entries.get(i);
+      if (entry == null)
+        continue;
+
+      String prefix = "entry." + i + ".";
+      SETTINGS.setAttribute(prefix + "type",entry.getType());
+      SETTINGS.setAttribute(prefix + "id",entry.getItemId());
+      SETTINGS.setAttribute(prefix + "name",entry.getName());
+      SETTINGS.setAttribute(prefix + "icon",entry.getIcon());
+    }
+  }
+
+  /**
+   * Prueft, ob ein Eintrag vorhanden ist.
+   * @param type Typ.
+   * @param id ID.
+   * @return true, wenn vorhanden.
+   */
+  public static boolean contains(String type, String id)
+  {
+    if (type == null || id == null)
+      return false;
+
+    try
+    {
+      String key = type + ":" + id;
+      for (IconBarEntry entry:getEntries())
+      {
+        if (key.equals(entry.getID()))
+          return true;
+      }
+    }
+    catch (RemoteException re)
+    {
+      Logger.error("unable to check icon bar entry",re);
+    }
+    return false;
+  }
+
+  /**
+   * Fuegt einen Eintrag hinzu.
+   * @param entry Eintrag.
+   */
+  public static void add(IconBarEntry entry)
+  {
+    if (entry == null)
+      return;
+
+    if (!IconBarEntry.TYPE_SPACER.equals(entry.getType()) && contains(entry.getType(),entry.getItemId()))
+      return;
+
+    List<IconBarEntry> entries = getEntries();
+    entries.add(entry);
+    setEntries(entries);
+  }
+
+  /**
+   * Entfernt einen Eintrag.
+   * @param entry Eintrag.
+   */
+  public static void remove(IconBarEntry entry)
+  {
+    if (entry == null)
+      return;
+
+    try
+    {
+      String key = entry.getID();
+      List<IconBarEntry> entries = getEntries();
+      List<IconBarEntry> keep = new ArrayList<IconBarEntry>();
+      for (IconBarEntry current:entries)
+      {
+        if (!key.equals(current.getID()))
+          keep.add(current);
+      }
+      setEntries(keep);
+    }
+    catch (RemoteException re)
+    {
+      Logger.error("unable to remove icon bar entry",re);
+    }
+  }
+
+  /**
+   * Initialisiert die Standard-Eintraege.
+   */
+  private static void ensureDefaults()
+  {
+    if (SETTINGS.getBoolean(KEY_DEFAULT,false))
+      return;
+
+    List<IconBarEntry> defaults = new ArrayList<IconBarEntry>();
+    defaults.add(new IconBarEntry(IconBarEntry.TYPE_NAVIGATION,"jameica.start","Start",null));
+    defaults.add(new IconBarEntry(IconBarEntry.TYPE_NAVIGATION,"jameica.appointments","Termine",null));
+    defaults.add(new IconBarEntry(IconBarEntry.TYPE_MENU,"jameica.menu.settings","Einstellungen",null));
+    setEntries(defaults);
+    SETTINGS.setAttribute(KEY_DEFAULT,true);
+  }
+
+  /**
+   * Loescht einen gespeicherten Eintrag.
+   * @param index Index.
+   */
+  private static void clear(int index)
+  {
+    String prefix = "entry." + index + ".";
+    SETTINGS.setAttribute(prefix + "type",(String)null);
+    SETTINGS.setAttribute(prefix + "id",(String)null);
+    SETTINGS.setAttribute(prefix + "name",(String)null);
+    SETTINGS.setAttribute(prefix + "icon",(String)null);
+  }
+}

--- a/src/de/willuhn/jameica/gui/Menu.java
+++ b/src/de/willuhn/jameica/gui/Menu.java
@@ -10,7 +10,9 @@
 package de.willuhn.jameica.gui;
 
 import java.rmi.RemoteException;
+import java.util.ArrayList;
 import java.util.Hashtable;
+import java.util.List;
 
 import org.eclipse.jface.bindings.keys.KeyStroke;
 import org.eclipse.jface.bindings.keys.SWTKeySupport;
@@ -43,6 +45,8 @@ public class Menu
 	private Decorations parent;
 
   private Hashtable itemLookup = new Hashtable();
+  private Hashtable idLookup = new Hashtable();
+  private Hashtable pluginLookup = new Hashtable();
   
   /**
    * Erzeugt eine neue Instanz des Dropdown-Menus.
@@ -59,7 +63,7 @@ public class Menu
   		parent.setMenuBar(mainMenu);
 
 		// System-Menu laden
-		load(Application.getManifest().getMenu(),mainMenu);
+		load(Application.getManifest().getMenu(),mainMenu,"Jameica");
   }
 
   /**
@@ -69,13 +73,24 @@ public class Menu
    */
 	protected void add(MenuItem menu) throws Exception
 	{
+    add(menu,null);
+	}
+
+  /**
+   * Fuegt weitere Sub-Menus hinzu.
+   * @param menu das hinzuzufuegende Menu.
+   * @param plugin Name des Plugins.
+   * @throws Exception
+   */
+	protected void add(MenuItem menu, String plugin) throws Exception
+	{
     if (menu == null || mainMenu == null)
       return;
     
     if (Customizing.SETTINGS.getBoolean("application.menu.hideplugins",false))
       return;
     
-    load(menu,mainMenu);
+    load(menu,mainMenu,plugin);
 	}
 
   /**
@@ -84,7 +99,7 @@ public class Menu
    * @param parentMenu
    * @throws Exception
    */
-  private void load(final MenuItem element, org.eclipse.swt.widgets.Menu parentMenu) throws Exception
+  private void load(final MenuItem element, org.eclipse.swt.widgets.Menu parentMenu, String plugin) throws Exception
   {
     if (element == null)
       return;
@@ -98,7 +113,7 @@ public class Menu
 		// Wenns keinen Namen hat, gibts nichts anzuzeigen und wir laden nur die Kinder,
 		if (name == null)
 		{
-			loadChildren(element,parentMenu);
+			loadChildren(element,parentMenu,plugin);
 			return;
 		}
 
@@ -112,6 +127,8 @@ public class Menu
     org.eclipse.swt.widgets.MenuItem item = new org.eclipse.swt.widgets.MenuItem(parentMenu,SWT.CASCADE);
 
     this.itemLookup.put(element,item);
+    this.idLookup.put(element.getID(),element);
+    this.pluginLookup.put(element.getID(),plugin);
 
     item.setData("item",element);
     item.setEnabled(element.isEnabled());
@@ -197,7 +214,7 @@ public class Menu
       // Wir laden die Kinder
       parentMenu = new org.eclipse.swt.widgets.Menu(parent,SWT.DROP_DOWN);
       item.setMenu(parentMenu);
-      loadChildren(element,parentMenu);
+      loadChildren(element,parentMenu,plugin);
       ////////////////////////////////////////////////////////////////////////////
     }
     else
@@ -213,7 +230,7 @@ public class Menu
    * @param menu Menu.
    * @throws Exception
    */
-  private void loadChildren(final MenuItem element, org.eclipse.swt.widgets.Menu menu) throws Exception
+  private void loadChildren(final MenuItem element, org.eclipse.swt.widgets.Menu menu, String plugin) throws Exception
 	{
 		// add elements
 		GenericIterator childs = element.getChildren();
@@ -221,8 +238,34 @@ public class Menu
 			return;
 		while (childs.hasNext())
 		{
-			load((MenuItem) childs.next(),menu);
+			load((MenuItem) childs.next(),menu,plugin);
 		}
+  }
+
+  /**
+   * Liefert alle ausfuehrbaren Menu-Eintraege.
+   * @return Eintraege fuer die Symbolleiste.
+   */
+  public List<IconBarEntry> getActionItems()
+  {
+    List<IconBarEntry> result = new ArrayList<IconBarEntry>();
+    for (Object current:this.idLookup.values())
+    {
+      try
+      {
+        MenuItem item = (MenuItem) current;
+        if (item.getAction() == null)
+          continue;
+        IconBarEntry entry = new IconBarEntry(IconBarEntry.TYPE_MENU,item.getID(),item.getName(),null);
+        entry.setPlugin((String) this.pluginLookup.get(item.getID()));
+        result.add(entry);
+      }
+      catch (Exception e)
+      {
+        Logger.error("unable to collect menu item",e);
+      }
+    }
+    return result;
   }
 
   /**
@@ -235,6 +278,18 @@ public class Menu
     org.eclipse.swt.widgets.MenuItem mi = (org.eclipse.swt.widgets.MenuItem) itemLookup.get(item);
     if (mi != null && !mi.isDisposed())
       mi.setEnabled(item.isEnabled());
+  }
+
+  /**
+   * Liefert ein Menu-Item anhand seiner ID.
+   * @param id ID.
+   * @return Menu-Item oder NULL.
+   */
+  public MenuItem getItem(String id)
+  {
+    if (id == null)
+      return null;
+    return (MenuItem) this.idLookup.get(id);
   }
 
 }

--- a/src/de/willuhn/jameica/gui/Navigation.java
+++ b/src/de/willuhn/jameica/gui/Navigation.java
@@ -10,8 +10,14 @@
 package de.willuhn.jameica.gui;
 
 import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
@@ -30,9 +36,11 @@ import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.swt.widgets.Widget;
 
 import de.willuhn.datasource.GenericIterator;
+import de.willuhn.jameica.gui.extension.Extension;
 import de.willuhn.jameica.gui.extension.ExtensionRegistry;
 import de.willuhn.jameica.gui.util.Color;
 import de.willuhn.jameica.gui.util.Font;
+import de.willuhn.jameica.messaging.MessageBus;
 import de.willuhn.jameica.messaging.StatusBarMessage;
 import de.willuhn.jameica.services.SystrayService;
 import de.willuhn.jameica.system.Application;
@@ -57,11 +65,15 @@ public class Navigation implements Part
   private Listener start        = new MyStartListener();
   private Settings settings     = new Settings(Navigation.class);
   private Tree mainTree					= null;
+  private NavigationItem contextItem = null;
   
 	// TreeItem, unterhalb dessen die Plugins eingehaengt werden. 
   private TreeItem pluginTree		= null;
   
   private Map<String,TreeItem> itemLookup  = new HashMap<String,TreeItem>();
+  private Map<String,String> pluginLookup  = new HashMap<String,String>();
+  private Map<String,NavigationItem> navigationLookup = new LinkedHashMap<String,NavigationItem>();
+  private Map<NavigationItem,String> navigationSource = new IdentityHashMap<NavigationItem,String>();
   
   /**
    * @see de.willuhn.jameica.gui.Part#paint(org.eclipse.swt.widgets.Composite)
@@ -91,6 +103,14 @@ public class Navigation implements Part
     this.mainTree.addListener(SWT.Collapse,         action); // Icon ersetzen
     this.mainTree.addListener(SWT.MouseUp,          action); // Single-Klick zum View starten
     this.mainTree.addListener(SWT.DefaultSelection, action); // Fuer Enter und Doppelklick
+    this.mainTree.addListener(SWT.MenuDetect, new Listener() {
+      public void handleEvent(Event event)
+      {
+        TreeItem item = mainTree.getItem(mainTree.toControl(event.x,event.y));
+        contextItem = item != null ? (NavigationItem) item.getData(KEY_NAVIGATION) : null;
+      }
+    });
+    createContextMenu();
     
     // Globaler Listener, um der Navi mittels ALT+N den Fokus zu geben
     GUI.getDisplay().addFilter(SWT.KeyUp, new Listener() {
@@ -131,7 +151,7 @@ public class Navigation implements Part
       try
       {
         // System-Navigation laden
-        load(Application.getManifest().getNavigation(),null);
+        load(Application.getManifest().getNavigation(),null,"Jameica");
       }
       catch (Exception e)
       {
@@ -141,12 +161,64 @@ public class Navigation implements Part
   }
 
   /**
+   * Erzeugt das Kontextmenu der Navigation.
+   */
+  private void createContextMenu()
+  {
+    final org.eclipse.swt.widgets.Menu menu = new org.eclipse.swt.widgets.Menu(this.mainTree);
+    this.mainTree.setMenu(menu);
+
+    final org.eclipse.swt.widgets.MenuItem add = new org.eclipse.swt.widgets.MenuItem(menu,SWT.PUSH);
+    add.setText(Application.getI18n().tr("Zur Symbolleiste hinzuf\u00fcgen"));
+    add.setImage(de.willuhn.jameica.gui.util.SWTUtil.getImage("list-add.png"));
+    add.addListener(SWT.Selection,new Listener()
+    {
+      public void handleEvent(Event event)
+      {
+        if (contextItem == null)
+          return;
+
+        try
+        {
+          IconBarSettings.add(new IconBarEntry(IconBarEntry.TYPE_NAVIGATION,contextItem.getID(),contextItem.getName(),null));
+          IconBarSettings.setVisible(true);
+          if (GUI.getIconBar() != null)
+            GUI.getIconBar().redraw();
+          Application.getMessagingFactory().sendMessage(new StatusBarMessage(Application.getI18n().tr("Eintrag zur Symbolleiste hinzugef\u00fcgt"),StatusBarMessage.TYPE_SUCCESS));
+        }
+        catch (Exception e)
+        {
+          Logger.error("unable to add navigation item to icon bar",e);
+          Application.getMessagingFactory().sendMessage(new StatusBarMessage(Application.getI18n().tr("Fehler beim Hinzuf\u00fcgen zur Symbolleiste"),StatusBarMessage.TYPE_ERROR));
+        }
+      }
+    });
+
+    menu.addListener(SWT.Show,new Listener()
+    {
+      public void handleEvent(Event event)
+      {
+        boolean enabled = false;
+        try
+        {
+          enabled = contextItem != null && contextItem.getAction() != null && contextItem.isEnabled() && !IconBarSettings.contains(IconBarEntry.TYPE_NAVIGATION,contextItem.getID());
+        }
+        catch (Exception e)
+        {
+          Logger.error("unable to update navigation context menu",e);
+        }
+        add.setEnabled(enabled);
+      }
+    });
+  }
+
+  /**
 	 * Laedt das Navigation-Item und dessen Kinder.
    * @param element das zu ladende Item.
    * @param parentTree uebergeordnetes SWT-Element.
    * @throws RemoteException
    */
-  private void load(NavigationItem element, TreeItem parentTree) throws RemoteException
+  private void load(NavigationItem element, TreeItem parentTree, String plugin) throws RemoteException
 	{
 		if (element == null)
 			return;
@@ -155,7 +227,7 @@ public class Navigation implements Part
 		
 		if (name == null)
 		{
-			loadChildren(element,parentTree);
+			loadChildren(element,parentTree,plugin);
 			return;
 		}
 
@@ -186,13 +258,14 @@ public class Navigation implements Part
     }
     
     this.itemLookup.put(element.getID(),item);
+    register(element,plugin);
 
     // Bevor wir die Kinder laden, geben wir das Element noch der
     // ExtensionRegistry fuer eventuell weitere Erweiterungen
-    ExtensionRegistry.extend(element);
+    extend(element);
 
 		// und laden nun unsere Kinder
-		loadChildren(element,item);
+		loadChildren(element,item,plugin);
 	}
 
   /**
@@ -246,16 +319,123 @@ public class Navigation implements Part
    * @param parentTree Parent.
 	 * @throws RemoteException
    */
-  private void loadChildren(NavigationItem element, TreeItem parentTree) throws RemoteException
+  private void loadChildren(NavigationItem element, TreeItem parentTree, String plugin) throws RemoteException
 	{
 		GenericIterator<?> childs = element.getChildren();
 		if (childs == null || childs.size() == 0)
 			return;
 		while (childs.hasNext())
 		{
-			load((NavigationItem) childs.next(),parentTree);
+      NavigationItem child = (NavigationItem) childs.next();
+      String childPlugin = this.navigationSource.get(child);
+			load(child,parentTree,childPlugin != null ? childPlugin : plugin);
 		}
 	}
+
+  /**
+   * Erweitert ein Navigation-Item und merkt sich die Herkunft neu hinzugefuegter Kinder.
+   * @param element Navigation-Item.
+   */
+  private void extend(NavigationItem element)
+  {
+    if (element == null)
+      return;
+
+    String id = element.getExtendableID();
+    if (id == null)
+      return;
+
+    int count = 0;
+    List<Extension> extensions = ExtensionRegistry.getExtensions(id);
+    if (extensions != null)
+    {
+      for (Extension extension:extensions)
+      {
+        try
+        {
+          Set<NavigationItem> before = Collections.newSetFromMap(new IdentityHashMap<NavigationItem,Boolean>());
+          before.addAll(children(element));
+          extension.extend(element);
+          count++;
+          rememberNewChildren(element,before,ExtensionRegistry.getSource(extension));
+        }
+        catch (Throwable t)
+        {
+          Logger.error("error while extending " + id,t);
+        }
+      }
+    }
+    MessageBus.sendSync(id,count);
+  }
+
+  /**
+   * Merkt sich die Herkunft neu hinzugefuegter Kinder.
+   * @param parent Eltern-Item.
+   * @param before Kinder vor der Erweiterung.
+   * @param plugin Plugin-Name.
+   * @throws RemoteException
+   */
+  private void rememberNewChildren(NavigationItem parent, Set<NavigationItem> before, String plugin) throws RemoteException
+  {
+    if (plugin == null)
+      return;
+
+    for (NavigationItem child:children(parent))
+    {
+      if (!before.contains(child))
+        rememberSource(child,plugin);
+    }
+  }
+
+  /**
+   * Merkt sich die Herkunft eines Navigation-Items und seiner Kinder.
+   * @param item Navigation-Item.
+   * @param plugin Plugin-Name.
+   * @throws RemoteException
+   */
+  private void rememberSource(NavigationItem item, String plugin) throws RemoteException
+  {
+    if (item == null || plugin == null)
+      return;
+
+    this.navigationSource.put(item,plugin);
+    for (NavigationItem child:children(item))
+      rememberSource(child,plugin);
+  }
+
+  /**
+   * Liefert die Kinder eines Navigation-Items als Liste.
+   * @param item Navigation-Item.
+   * @return Kinder.
+   * @throws RemoteException
+   */
+  private List<NavigationItem> children(NavigationItem item) throws RemoteException
+  {
+    List<NavigationItem> result = new ArrayList<NavigationItem>();
+    GenericIterator<?> children = item.getChildren();
+    while (children != null && children.hasNext())
+      result.add((NavigationItem) children.next());
+    return result;
+  }
+
+  /**
+   * Merkt sich ein Navigation-Item unabhaengig vom sichtbaren TreeItem.
+   * @param element Navigation-Item.
+   * @param plugin Name des Plugins.
+   * @throws RemoteException
+   */
+  private void register(NavigationItem element, String plugin) throws RemoteException
+  {
+    if (element == null)
+      return;
+
+    String id = element.getID();
+    if (id == null)
+      return;
+
+    this.navigationLookup.put(id,element);
+    this.pluginLookup.put(id,plugin);
+  }
 
   /**
 	 * Fuegt einen weiteren Navigationszweig hinzu.
@@ -264,9 +444,20 @@ public class Navigation implements Part
    */
   protected void add(NavigationItem navi) throws Exception
 	{
+    add(navi,null);
+	}
+
+  /**
+   * Fuegt einen weiteren Navigationszweig hinzu.
+   * @param navi das hinzuzufuegende Navigations-Element.
+   * @param plugin Name des Plugins.
+   * @throws Exception
+   */
+  protected void add(NavigationItem navi, String plugin) throws Exception
+	{
 		if (navi == null)
 			return;
-		load(navi,this.pluginTree);
+		load(navi,this.pluginTree,plugin);
 	}
   
   /**
@@ -285,14 +476,69 @@ public class Navigation implements Part
     if (ti == null || ti.isDisposed())
       return;
     
+    NavigationItem current = this.navigationLookup.get(item.getID());
+    if (current != null && current != item)
+      unregisterChildren(current);
+
     //Existierende Childs entfernen
     for (TreeItem i : ti.getItems())
     {
+      unregister((NavigationItem) i.getData(KEY_NAVIGATION));
       i.dispose();
     }
     
     //Childs neu laden
-    loadChildren(item,ti);
+    loadChildren(item,ti,this.pluginLookup.get(item.getID()));
+  }
+
+  /**
+   * Entfernt die Kinder eines Navigation-Items aus dem Katalog.
+   * @param item Navigation-Item.
+   */
+  private void unregisterChildren(NavigationItem item)
+  {
+    if (item == null)
+      return;
+
+    try
+    {
+      GenericIterator<?> children = item.getChildren();
+      while (children != null && children.hasNext())
+        unregister((NavigationItem) children.next());
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to unregister navigation item children",e);
+    }
+  }
+
+  /**
+   * Entfernt ein Navigation-Item und dessen Kinder aus dem Katalog.
+   * @param item Navigation-Item.
+   */
+  private void unregister(NavigationItem item)
+  {
+    if (item == null)
+      return;
+
+    try
+    {
+      String id = item.getID();
+      if (id != null)
+      {
+        this.navigationLookup.remove(id);
+        this.pluginLookup.remove(id);
+        this.navigationSource.remove(item);
+      }
+
+      GenericIterator<?> children = item.getChildren();
+      while (children != null && children.hasNext())
+        unregister((NavigationItem) children.next());
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to unregister navigation item",e);
+    }
   }
 
   /**
@@ -305,6 +551,10 @@ public class Navigation implements Part
     if (item == null)
       return;
 
+    String id = item.getID();
+    if (id != null && this.navigationLookup.containsKey(id))
+      this.navigationLookup.put(id,item);
+
     TreeItem ti = this.itemLookup.get(item.getID());
     if (ti == null || ti.isDisposed())
       return;
@@ -313,6 +563,65 @@ public class Navigation implements Part
     ti.setForeground(item.isEnabled() ? Color.FOREGROUND.getSWTColor() : Color.COMMENT.getSWTColor());
     ti.setText(item.getName());
     ti.setData(KEY_NAVIGATION,item);
+  }
+
+  /**
+   * Liefert ein Navigation-Item anhand seiner ID.
+   * @param id ID.
+   * @return Navigation-Item oder NULL.
+   */
+  public NavigationItem getItem(String id)
+  {
+    if (id == null)
+      return null;
+
+    NavigationItem item = this.navigationLookup.get(id);
+    if (item != null)
+      return item;
+
+    TreeItem ti = this.itemLookup.get(id);
+    if (ti == null || ti.isDisposed())
+      return null;
+
+    return (NavigationItem) ti.getData(KEY_NAVIGATION);
+  }
+
+  /**
+   * Liefert alle ausfuehrbaren Navigationseintraege.
+   * @return Eintraege fuer die Symbolleiste.
+   */
+  public java.util.List<IconBarEntry> getActionItems()
+  {
+    List<IconBarEntry> result = new ArrayList<IconBarEntry>();
+    for (NavigationItem item:this.navigationLookup.values())
+      collectActionItem(item,result);
+
+    return result;
+  }
+
+  /**
+   * Sammelt einen ausfuehrbaren Navigationseintrag.
+   * @param item Navigation-Item.
+   * @param result Ergebnisliste.
+   */
+  private void collectActionItem(NavigationItem item, List<IconBarEntry> result)
+  {
+    if (item == null)
+      return;
+
+    try
+    {
+      if (item.getAction() != null)
+      {
+        IconBarEntry entry = new IconBarEntry(IconBarEntry.TYPE_NAVIGATION,item.getID(),item.getName(),null);
+        entry.setPlugin(this.pluginLookup.get(item.getID()));
+        result.add(entry);
+      }
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to collect navigation item",e);
+    }
   }
 
   /**

--- a/src/de/willuhn/jameica/gui/dialogs/SearchableListDialog.java
+++ b/src/de/willuhn/jameica/gui/dialogs/SearchableListDialog.java
@@ -1,0 +1,266 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2026 Olaf Willuhn
+ * All rights reserved.
+ * 
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details. 
+ *
+ **********************************************************************/
+package de.willuhn.jameica.gui.dialogs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Text;
+
+import de.willuhn.datasource.BeanUtil;
+import de.willuhn.datasource.GenericIterator;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.formatter.Formatter;
+import de.willuhn.jameica.gui.formatter.TableFormatter;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.parts.Column;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.gui.parts.table.FeatureSummary;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * Dialog, der eine durchsuchbare Tabelle mit Daten aus einer Liste anzeigt.
+ */
+public class SearchableListDialog extends AbstractDialog
+{
+  private Object object            = null;
+  private GenericIterator iterator = null;
+  private List list                = null;
+  private List<Column> columns     = new ArrayList<Column>();
+  private TableFormatter formatter = null;
+
+  /**
+   * ct.
+   * @param list anzuzeigende Liste.
+   * @param position Position.
+   */
+  public SearchableListDialog(GenericIterator list, int position)
+  {
+    this(position);
+    this.iterator = list;
+  }
+
+  /**
+   * ct.
+   * @param list anzuzeigende Liste.
+   * @param position Position.
+   */
+  public SearchableListDialog(List list, int position)
+  {
+    this(position);
+    this.list = list;
+  }
+
+  /**
+   * ct.
+   * @param position Position.
+   */
+  private SearchableListDialog(int position)
+  {
+    super(position);
+    setSize(SWT.DEFAULT,420);
+  }
+
+  /**
+   * Fuegt der Tabelle eine weitere Spalte hinzu.
+   * @param title Ueberschrift der Spalte.
+   * @param field Feld fuer den anzuzeigenden Wert.
+   */
+  public void addColumn(String title, String field)
+  {
+    addColumn(title,field,null);
+  }
+
+  /**
+   * Fuegt der Tabelle eine weitere Spalte hinzu.
+   * @param title Ueberschrift der Spalte.
+   * @param field Feld fuer den anzuzeigenden Wert.
+   * @param f Formatierer.
+   */
+  public void addColumn(String title, String field, Formatter f)
+  {
+    if (title == null || field == null)
+      return;
+
+    addColumn(new Column(field,title,f));
+  }
+
+  /**
+   * Fuegt eine Spalte hinzu.
+   * @param col Spalte.
+   */
+  public void addColumn(Column col)
+  {
+    if (col == null)
+      return;
+    this.columns.add(col);
+  }
+
+  /**
+   * Definiert einen optionalen Formatter fuer die Tabelle.
+   * @param formatter Formatter.
+   */
+  public void setFormatter(TableFormatter formatter)
+  {
+    this.formatter = formatter;
+  }
+
+  /**
+   * @see de.willuhn.jameica.gui.dialogs.AbstractDialog#paint(org.eclipse.swt.widgets.Composite)
+   */
+  protected void paint(Composite parent) throws Exception
+  {
+    final List items = getSourceItems();
+    final TablePart table = new TablePart(items,new MyAction());
+
+    final Text search = new Text(parent,SWT.SEARCH | SWT.ICON_SEARCH | SWT.CANCEL);
+    search.setMessage(i18n.tr("Suchen..."));
+    search.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+    search.addModifyListener(new ModifyListener()
+    {
+      public void modifyText(ModifyEvent event)
+      {
+        try
+        {
+          applySearch(table,items,search.getText());
+        }
+        catch (Exception e)
+        {
+          Logger.error("unable to filter searchable list dialog",e);
+        }
+      }
+    });
+
+    for (Column c:this.columns)
+      table.addColumn(c);
+
+    if (this.formatter != null)
+      table.setFormatter(this.formatter);
+
+    table.removeFeature(FeatureSummary.class);
+    table.setMulti(false);
+    table.setRememberColWidths(true);
+    table.setRememberOrder(true);
+    table.setRememberState(false);
+    table.paint(parent);
+
+    ButtonArea b = new ButtonArea();
+    b.addButton(i18n.tr("\u00dcbernehmen"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
+        object = table.getSelection();
+        close();
+      }
+    });
+    b.addButton(i18n.tr("Abbrechen"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
+        object = null;
+        throw new OperationCanceledException();
+      }
+    });
+    b.paint(parent);
+  }
+
+  /**
+   * Liefert die Datenquelle als Liste.
+   * @return Liste.
+   */
+  private List getSourceItems()
+  {
+    if (this.list != null)
+      return this.list;
+
+    List result = new ArrayList();
+    try
+    {
+      while (this.iterator != null && this.iterator.hasNext())
+        result.add(this.iterator.next());
+    }
+    catch (Exception e)
+    {
+      throw new RuntimeException(e);
+    }
+    return result;
+  }
+
+  /**
+   * Wendet den Suchfilter auf die Tabelle an.
+   * @param table Tabelle.
+   * @param source vollstaendige Quellliste.
+   * @param query Suchbegriff.
+   * @throws Exception
+   */
+  private void applySearch(TablePart table, List source, String query) throws Exception
+  {
+    String filter = query == null ? null : query.trim().toLowerCase();
+    table.removeAll();
+
+    for (Object item:source)
+    {
+      if (filter == null || filter.length() == 0 || matches(item,filter))
+        table.addItem(item);
+    }
+  }
+
+  /**
+   * Prueft, ob der Suchbegriff in einer Spalte enthalten ist.
+   * @param item Eintrag.
+   * @param filter Suchbegriff in Kleinschreibung.
+   * @return true, wenn passend.
+   */
+  private boolean matches(Object item, String filter)
+  {
+    for (Column column:this.columns)
+    {
+      try
+      {
+        Object value = BeanUtil.get(item,column.getColumnId());
+        String display = column.getFormattedValue(value,item);
+        if (display != null && display.toLowerCase().contains(filter))
+          return true;
+      }
+      catch (Exception e)
+      {
+        // Fehlerhafte Spaltenwerte ignorieren wir fuer die Suche.
+      }
+    }
+    return false;
+  }
+
+  /**
+   * @see de.willuhn.jameica.gui.dialogs.AbstractDialog#getData()
+   */
+  protected Object getData() throws Exception
+  {
+    return object;
+  }
+
+  /**
+   * Hilfsklasse fuer die Aktion beim Doppelklick auf einen Datensatz.
+   */
+  private class MyAction implements Action
+  {
+    public void handleAction(Object context) throws ApplicationException
+    {
+      object = context;
+      close();
+    }
+  }
+}

--- a/src/de/willuhn/jameica/gui/extension/ExtensionRegistry.java
+++ b/src/de/willuhn/jameica/gui/extension/ExtensionRegistry.java
@@ -12,6 +12,7 @@ package de.willuhn.jameica.gui.extension;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +29,7 @@ public class ExtensionRegistry
 {
 
   private static Map<String,List<Extension>> extensions = new HashMap<String,List<Extension>>();
+  private static Map<Extension,String> sources = new IdentityHashMap<Extension,String>();
   
   /**
    * Erweitert das Extendable insofern Extensions registriert sind.
@@ -70,7 +72,20 @@ public class ExtensionRegistry
    */
   public static void register(Extension extension, String[] extendableIDs)
   {
-      
+    register(extension,extendableIDs,null);
+  }
+
+  /**
+   * Registriert das Erweiterungsmodul unter den genannten IDs.
+   * @param extension
+   * @param extendableIDs
+   * @param source Name des Plugins, aus dem die Extension stammt.
+   */
+  public static void register(Extension extension, String[] extendableIDs, String source)
+  {
+    if (extension != null && source != null)
+      sources.put(extension,source);
+
     for (int i=0;i<extendableIDs.length;++i)
     {
       List<Extension> v = extensions.get(extendableIDs[i]);
@@ -90,6 +105,16 @@ public class ExtensionRegistry
   public static void register(Extension extension, String extendableID)
   {
     register(extension, new String[]{extendableID});
+  }
+
+  /**
+   * Liefert den Namen des Plugins, aus dem die Extension stammt.
+   * @param extension Extension.
+   * @return Plugin-Name oder NULL.
+   */
+  public static String getSource(Extension extension)
+  {
+    return extension == null ? null : sources.get(extension);
   }
 
   /**

--- a/src/de/willuhn/jameica/gui/internal/action/IconBarToggle.java
+++ b/src/de/willuhn/jameica/gui/internal/action/IconBarToggle.java
@@ -1,0 +1,34 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2026 Olaf Willuhn
+ * All rights reserved.
+ * 
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details. 
+ *
+ **********************************************************************/
+package de.willuhn.jameica.gui.internal.action;
+
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.IconBarSettings;
+import de.willuhn.jameica.messaging.StatusBarMessage;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * Blendet die Symbolleiste ein oder aus.
+ */
+public class IconBarToggle implements Action
+{
+  /**
+   * @see de.willuhn.jameica.gui.Action#handleAction(java.lang.Object)
+   */
+  public void handleAction(Object context) throws ApplicationException
+  {
+    boolean visible = IconBarSettings.toggleVisible();
+    if (GUI.getIconBar() != null)
+      GUI.getIconBar().redraw();
+    Application.getMessagingFactory().sendMessage(new StatusBarMessage(Application.getI18n().tr(visible ? "Symbolleiste eingeblendet" : "Symbolleiste ausgeblendet"),StatusBarMessage.TYPE_SUCCESS));
+  }
+}

--- a/src/de/willuhn/jameica/gui/internal/controller/SettingsControl.java
+++ b/src/de/willuhn/jameica/gui/internal/controller/SettingsControl.java
@@ -29,6 +29,7 @@ import de.willuhn.jameica.gui.input.IntegerInput;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.internal.parts.CertificateList;
+import de.willuhn.jameica.gui.internal.parts.IconBarSettingsPart;
 import de.willuhn.jameica.gui.internal.parts.PluginDetailPart.Type;
 import de.willuhn.jameica.gui.internal.parts.PluginListPart;
 import de.willuhn.jameica.gui.parts.TablePart;
@@ -79,6 +80,7 @@ public class SettingsControl extends AbstractControl
   private CheckboxInput randomSplash;
   private CheckboxInput systray;
   private CheckboxInput minimizeToSystray;
+  private IconBarSettingsPart iconBarSettings;
 	
   /**
    * ct.
@@ -391,6 +393,18 @@ public class SettingsControl extends AbstractControl
   }
 
   /**
+   * Liefert die Einstellungen fuer die Symbolleiste.
+   * @return Einstellungen fuer die Symbolleiste.
+   */
+  public IconBarSettingsPart getIconBarSettings()
+  {
+    if (this.iconBarSettings != null)
+      return this.iconBarSettings;
+    this.iconBarSettings = new IconBarSettingsPart();
+    return this.iconBarSettings;
+  }
+
+  /**
    * Speichert die Einstellungen.
    */
   public void handleStore()
@@ -441,6 +455,7 @@ public class SettingsControl extends AbstractControl
       final SystrayService systray = Application.getBootLoader().getBootable(SystrayService.class);
       systray.setEnabled(((Boolean)getSystray().getValue()).booleanValue());
       systray.setMinimizeToSystray(((Boolean)getMinimizeToSystray().getValue()).booleanValue());
+      getIconBarSettings().apply();
       
       Application.getMessagingFactory().sendSyncMessage(new SettingsChangedMessage());
       Application.getMessagingFactory().sendMessage(new StatusBarMessage(Application.getI18n().tr("Einstellungen gespeichert."),StatusBarMessage.TYPE_SUCCESS));

--- a/src/de/willuhn/jameica/gui/internal/parts/IconBarSettingsPart.java
+++ b/src/de/willuhn/jameica/gui/internal/parts/IconBarSettingsPart.java
@@ -1,0 +1,912 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2026 Olaf Willuhn
+ * All rights reserved.
+ * 
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details. 
+ *
+ **********************************************************************/
+package de.willuhn.jameica.gui.internal.parts;
+
+import java.io.File;
+import java.io.InputStream;
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.TableItem;
+
+import de.willuhn.datasource.GenericObject;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.IconBarEntry;
+import de.willuhn.jameica.gui.IconBarSettings;
+import de.willuhn.jameica.gui.Part;
+import de.willuhn.jameica.gui.formatter.TableFormatter;
+import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.dialogs.SearchableListDialog;
+import de.willuhn.jameica.gui.input.CheckboxInput;
+import de.willuhn.jameica.gui.input.SelectInput;
+import de.willuhn.jameica.gui.parts.Button;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.gui.parts.table.FeatureSummary;
+import de.willuhn.jameica.gui.util.SWTUtil;
+import de.willuhn.jameica.plugin.Manifest;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * Einstellungen fuer die Symbolleiste.
+ */
+public class IconBarSettingsPart implements Part
+{
+  private CheckboxInput visible;
+  private SelectInput size;
+  private TablePart table;
+  private Button remove;
+  private Button up;
+  private Button down;
+  private Button icon;
+  private Button resetIcon;
+  private List<Image> tableImages = new ArrayList<Image>();
+  private boolean entriesChanged = false;
+
+  /**
+   * @see de.willuhn.jameica.gui.Part#paint(org.eclipse.swt.widgets.Composite)
+   */
+  public void paint(Composite parent) throws RemoteException
+  {
+    getVisible().paint(parent);
+    getSize().paint(parent);
+    getTable().paint(parent);
+    parent.addDisposeListener(event -> disposeTableImages());
+
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton(new Button(Application.getI18n().tr("Hinzuf\u00fcgen"),new Add(),null,false,"list-add.png"));
+    buttons.addButton(new Button(Application.getI18n().tr("Abstand einf\u00fcgen"),new AddSpacer(),null,false,"go-next.png"));
+    buttons.addButton(getRemoveButton());
+    buttons.addButton(getUpButton());
+    buttons.addButton(getDownButton());
+    buttons.addButton(getIconButton());
+    buttons.addButton(getResetIconButton());
+    buttons.paint(parent);
+  }
+
+  /**
+   * Speichert die Einstellungen.
+   */
+  public void apply()
+  {
+    try
+    {
+      IconBarSettings.setVisible(((Boolean)getVisible().getValue()).booleanValue());
+      IconBarSettings.setSize((String)getSize().getValue());
+      if (this.entriesChanged)
+        IconBarSettings.setEntries(getTable().getItems(false));
+      if (GUI.getIconBar() != null)
+        GUI.getIconBar().redraw();
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to save icon bar settings",e);
+    }
+  }
+
+  /**
+   * Liefert die Checkbox fuer die Sichtbarkeit.
+   * @return Checkbox.
+   */
+  private CheckboxInput getVisible()
+  {
+    if (this.visible != null)
+      return this.visible;
+    this.visible = new CheckboxInput(IconBarSettings.isVisible());
+    this.visible.setName(Application.getI18n().tr("Symbolleiste anzeigen"));
+    return this.visible;
+  }
+
+  /**
+   * Liefert die Auswahl fuer die Groesse.
+   * @return Auswahl.
+   */
+  private SelectInput getSize()
+  {
+    if (this.size != null)
+      return this.size;
+
+    List<String> sizes = new ArrayList<String>();
+    sizes.add(IconBarSettings.SIZE_SMALL);
+    sizes.add(IconBarSettings.SIZE_MEDIUM);
+    sizes.add(IconBarSettings.SIZE_LARGE);
+    this.size = new SelectInput(sizes,IconBarSettings.getSize()) {
+      protected String format(Object bean)
+      {
+        if (IconBarSettings.SIZE_SMALL.equals(bean))
+          return Application.getI18n().tr("Klein");
+        if (IconBarSettings.SIZE_LARGE.equals(bean))
+          return Application.getI18n().tr("Gro\u00df");
+        return Application.getI18n().tr("Mittel");
+      }
+    };
+    this.size.setName(Application.getI18n().tr("Icon-Gr\u00f6sse"));
+    this.size.addListener(event -> refreshTable());
+    return this.size;
+  }
+
+  /**
+   * Liefert die Tabelle.
+   * @return Tabelle.
+   */
+  private TablePart getTable()
+  {
+    if (this.table != null)
+      return this.table;
+
+    this.table = new TablePart(IconBarSettings.getEntries(),null);
+    this.table.addColumn(Application.getI18n().tr("Bezeichnung"),"name");
+    this.table.addColumn(Application.getI18n().tr("Quelle"),"source");
+    this.table.addColumn(Application.getI18n().tr("Icon"),"icon");
+    this.table.addColumn(Application.getI18n().tr("Ziel"),"itemId");
+    this.table.setFormatter(new EntryFormatter());
+    this.table.setMulti(false);
+    this.table.setRememberOrder(false);
+    this.table.setSortable(false);
+    this.table.removeFeature(FeatureSummary.class);
+    this.table.addSelectionListener(event -> updateButtons());
+    return this.table;
+  }
+
+  /**
+   * Aktualisiert die Buttons.
+   */
+  private void updateButtons()
+  {
+    IconBarEntry entry = (IconBarEntry) getTable().getSelection();
+    boolean selected = entry != null;
+    boolean spacer = selected && IconBarEntry.TYPE_SPACER.equals(entry.getType());
+    boolean hasCustomIcon = selected && !spacer && StringUtils.trimToNull(entry.getIcon()) != null;
+    if (this.remove != null)
+      this.remove.setEnabled(selected);
+    if (this.up != null)
+      this.up.setEnabled(selected);
+    if (this.down != null)
+      this.down.setEnabled(selected);
+    if (this.icon != null)
+      this.icon.setEnabled(selected && !spacer);
+    if (this.resetIcon != null)
+      this.resetIcon.setEnabled(hasCustomIcon);
+  }
+
+  /**
+   * Aktualisiert die Tabelle.
+   */
+  private void refreshTable()
+  {
+    if (this.table == null)
+      return;
+
+    try
+    {
+      Object selection = this.table.getSelection();
+      List items = this.table.getItems(false);
+      this.table.removeAll();
+      disposeTableImages();
+      for (Object item:items)
+        this.table.addItem(item);
+      if (selection != null)
+        this.table.select(selection);
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to refresh icon bar settings table",e);
+    }
+  }
+
+  /**
+   * Entsorgt die fuer die Tabelle skalierten Bilder.
+   */
+  private void disposeTableImages()
+  {
+    for (Image image:this.tableImages)
+    {
+      if (image != null && !image.isDisposed())
+        image.dispose();
+    }
+    this.tableImages.clear();
+  }
+
+  private Button getRemoveButton()
+  {
+    if (this.remove != null)
+      return this.remove;
+    this.remove = new Button(Application.getI18n().tr("Entfernen"),new Remove(),null,false,"list-remove.png");
+    this.remove.setEnabled(false);
+    return this.remove;
+  }
+
+  private Button getUpButton()
+  {
+    if (this.up != null)
+      return this.up;
+    this.up = new Button(Application.getI18n().tr("Nach oben"),new Move(-1),null,false,"maximize.png");
+    this.up.setEnabled(false);
+    return this.up;
+  }
+
+  private Button getDownButton()
+  {
+    if (this.down != null)
+      return this.down;
+    this.down = new Button(Application.getI18n().tr("Nach unten"),new Move(1),null,false,"minimize.png");
+    this.down.setEnabled(false);
+    return this.down;
+  }
+
+  private Button getIconButton()
+  {
+    if (this.icon != null)
+      return this.icon;
+    this.icon = new Button(Application.getI18n().tr("Icon w\u00e4hlen"),new ChooseIcon(),null,false,"document-open.png");
+    this.icon.setEnabled(false);
+    return this.icon;
+  }
+
+  private Button getResetIconButton()
+  {
+    if (this.resetIcon != null)
+      return this.resetIcon;
+    this.resetIcon = new Button(Application.getI18n().tr("Icon zur\u00fccksetzen"),new ResetIcon(),null,false,"edit-undo.png");
+    this.resetIcon.setEnabled(false);
+    return this.resetIcon;
+  }
+
+  /**
+   * Formatiert die Eintraege der Symbolleiste.
+   */
+  private class EntryFormatter implements TableFormatter
+  {
+    public void format(TableItem item)
+    {
+      if (item == null || !(item.getData() instanceof IconBarEntry))
+        return;
+
+      IconBarEntry entry = (IconBarEntry) item.getData();
+      if (IconBarEntry.TYPE_SPACER.equals(entry.getType()))
+      {
+        item.setText(0,Application.getI18n().tr("Abstand"));
+        item.setText(1,Application.getI18n().tr("Abstand"));
+        item.setText(2,"");
+        item.setText(3,"");
+        return;
+      }
+
+      org.eclipse.swt.graphics.Image image = null;
+      String icon = StringUtils.trimToNull(entry.getIcon());
+      if (icon != null)
+      {
+        image = SWTUtil.getImage(icon);
+        item.setText(2,"");
+      }
+      else
+      {
+        de.willuhn.jameica.gui.Item source = de.willuhn.jameica.gui.IconBar.resolve(entry);
+        image = getDefaultImage(source);
+        item.setText(2,"");
+      }
+
+      if (image != null && !image.isDisposed())
+        item.setImage(2,scaleTableImage(image));
+    }
+  }
+
+  /**
+   * Skaliert ein Bild fuer die Tabelle.
+   * @param image Bild.
+   * @return skaliertes Bild.
+   */
+  private Image scaleTableImage(Image image)
+  {
+    if (image == null || image.isDisposed())
+      return null;
+
+    int size = getSelectedIconSize();
+    Rectangle bounds = image.getBounds();
+    if (bounds.width <= 1 || bounds.height <= 1)
+      return null;
+
+    if (bounds.width == size && bounds.height == size)
+      return image;
+
+    ImageData data = image.getImageData().scaledTo(size,size);
+    Image scaled = new Image(GUI.getDisplay(),data);
+    this.tableImages.add(scaled);
+    return scaled;
+  }
+
+  /**
+   * Liefert die im Dialog ausgewaehlte Icon-Groesse.
+   * @return Icon-Groesse.
+   */
+  private int getSelectedIconSize()
+  {
+    Object selected = getSize().getValue();
+    if (IconBarSettings.SIZE_SMALL.equals(selected))
+      return 16;
+    if (IconBarSettings.SIZE_LARGE.equals(selected))
+      return 32;
+    return 24;
+  }
+
+  /**
+   * Liefert das Standard-Icon eines Eintrags.
+   * @param item Quell-Item.
+   * @return Icon oder NULL.
+   */
+  private org.eclipse.swt.graphics.Image getDefaultImage(de.willuhn.jameica.gui.Item item)
+  {
+    try
+    {
+      if (item instanceof de.willuhn.jameica.gui.NavigationItem)
+        return ((de.willuhn.jameica.gui.NavigationItem)item).getIconClose();
+      if (item instanceof de.willuhn.jameica.gui.MenuItem)
+        return ((de.willuhn.jameica.gui.MenuItem)item).getIcon();
+      if (item != null && IconBarEntry.TYPE_BOOKMARK.equals(item.getAttribute("type")))
+        return SWTUtil.getImage("starred.png");
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to resolve icon bar entry image",e);
+    }
+    return null;
+  }
+
+  /**
+   * Action zum Hinzuf\u00fcgen.
+   */
+  private class Add implements Action
+  {
+    public void handleAction(Object context) throws ApplicationException
+    {
+      try
+      {
+        List<IconBarEntry> items = new ArrayList<IconBarEntry>();
+        items.addAll(GUI.getNavigation().getActionItems());
+        items.addAll(GUI.getMenu().getActionItems());
+        items.addAll(de.willuhn.jameica.gui.IconBar.getBookmarkItems());
+        SearchableListDialog dialog = new SearchableListDialog(items,AbstractDialog.POSITION_CENTER);
+        dialog.setTitle(Application.getI18n().tr("Eintrag w\u00e4hlen"));
+        dialog.addColumn(Application.getI18n().tr("Bezeichnung"),"name");
+        dialog.addColumn(Application.getI18n().tr("Quelle"),"source");
+        dialog.addColumn(Application.getI18n().tr("Plugin"),"plugin");
+        dialog.addColumn(Application.getI18n().tr("ID"),"itemId");
+        IconBarEntry entry = (IconBarEntry) dialog.open();
+        if (entry == null)
+          return;
+
+        for (Object current:getTable().getItems(false))
+        {
+          IconBarEntry e = (IconBarEntry) current;
+          if (e.getType().equals(entry.getType()) && e.getItemId().equals(entry.getItemId()))
+            return;
+        }
+
+        getTable().addItem(entry);
+        getTable().select(entry);
+        entriesChanged = true;
+        updateButtons();
+      }
+      catch (Exception e)
+      {
+        if (e instanceof OperationCanceledException)
+        {
+          Logger.debug("operation cancelled");
+          return;
+        }
+        Logger.error("unable to add icon bar entry",e);
+      }
+    }
+  }
+
+  /**
+   * Action zum Einfuegen eines Abstands.
+   */
+  private class AddSpacer implements Action
+  {
+    public void handleAction(Object context) throws ApplicationException
+    {
+      try
+      {
+        IconBarEntry spacer = IconBarEntry.createSpacer();
+        IconBarEntry selected = (IconBarEntry) getTable().getSelection();
+        int target = getTable().size();
+        if (selected != null)
+        {
+          List items = getTable().getItems(false);
+          int index = items.indexOf(selected);
+          if (index >= 0)
+            target = index + 1;
+        }
+
+        getTable().addItem(spacer,target);
+        getTable().select(spacer);
+        entriesChanged = true;
+        updateButtons();
+      }
+      catch (Exception e)
+      {
+        Logger.error("unable to add icon bar spacer",e);
+      }
+    }
+  }
+
+  /**
+   * Action zum Entfernen.
+   */
+  private class Remove implements Action
+  {
+    public void handleAction(Object context) throws ApplicationException
+    {
+      IconBarEntry entry = (IconBarEntry) getTable().getSelection();
+      if (entry == null)
+        return;
+      getTable().removeItem(entry);
+      entriesChanged = true;
+      updateButtons();
+    }
+  }
+
+  /**
+   * Action zum Verschieben.
+   */
+  private class Move implements Action
+  {
+    private int direction;
+
+    private Move(int direction)
+    {
+      this.direction = direction;
+    }
+
+    public void handleAction(Object context) throws ApplicationException
+    {
+      try
+      {
+        IconBarEntry entry = (IconBarEntry) getTable().getSelection();
+        if (entry == null)
+          return;
+
+        int index = getTable().removeItem(entry);
+        if (index == -1)
+          return;
+
+        int target = index + this.direction;
+        if (target < 0)
+          target = 0;
+        if (target > getTable().size())
+          target = getTable().size();
+
+        getTable().addItem(entry,target);
+        getTable().select(entry);
+        entriesChanged = true;
+        updateButtons();
+      }
+      catch (Exception e)
+      {
+        Logger.error("unable to move icon bar entry",e);
+      }
+    }
+  }
+
+  /**
+   * Action zum Ausw\u00e4hlen eines Icons.
+   */
+  private class ChooseIcon implements Action
+  {
+    public void handleAction(Object context) throws ApplicationException
+    {
+      try
+      {
+        IconBarEntry entry = (IconBarEntry) getTable().getSelection();
+        if (entry == null)
+          return;
+        if (IconBarEntry.TYPE_SPACER.equals(entry.getType()))
+          return;
+
+        List<IconFile> icons = getIcons();
+        SearchableListDialog dialog = new SearchableListDialog(icons,AbstractDialog.POSITION_CENTER);
+        dialog.setTitle(Application.getI18n().tr("Icon w\u00e4hlen"));
+        dialog.addColumn(Application.getI18n().tr("Vorschau"),"preview");
+        dialog.addColumn(Application.getI18n().tr("Datei"),"name");
+        IconFileFormatter formatter = new IconFileFormatter();
+        dialog.setFormatter(formatter);
+        IconFile icon = null;
+        try
+        {
+          icon = (IconFile) dialog.open();
+        }
+        finally
+        {
+          formatter.dispose();
+        }
+        if (icon == null)
+          return;
+
+        int index = getTable().removeItem(entry);
+        entry.setIcon(icon.getName());
+        getTable().addItem(entry,index);
+        getTable().select(entry);
+        entriesChanged = true;
+        updateButtons();
+        updateButtons();
+      }
+      catch (Exception e)
+      {
+        if (e instanceof OperationCanceledException)
+        {
+          Logger.debug("operation cancelled");
+          return;
+        }
+        Logger.error("unable to choose icon",e);
+      }
+    }
+  }
+
+  /**
+   * Action zum Zuruecksetzen des Icons.
+   */
+  private class ResetIcon implements Action
+  {
+    public void handleAction(Object context) throws ApplicationException
+    {
+      try
+      {
+        IconBarEntry entry = (IconBarEntry) getTable().getSelection();
+        if (entry == null)
+          return;
+        if (IconBarEntry.TYPE_SPACER.equals(entry.getType()))
+          return;
+
+        int index = getTable().removeItem(entry);
+        entry.setIcon(null);
+        getTable().addItem(entry,index);
+        getTable().select(entry);
+        entriesChanged = true;
+        updateButtons();
+      }
+      catch (Exception e)
+      {
+        Logger.error("unable to reset icon",e);
+      }
+    }
+  }
+
+  /**
+   * Formatiert die Icon-Auswahl mit Vorschau.
+   */
+  private class IconFileFormatter implements TableFormatter
+  {
+    private List<Image> images = new ArrayList<Image>();
+
+    public void format(TableItem item)
+    {
+      if (item == null || item.getData() == null || !(item.getData() instanceof IconFile))
+        return;
+
+      IconFile icon = (IconFile) item.getData();
+      Image image = scale(SWTUtil.getImage(icon.getName()),IconBarSettings.getIconSize());
+      if (image != null && !image.isDisposed())
+        item.setImage(0,image);
+    }
+
+    /**
+     * Skaliert ein Bild fuer die Vorschau.
+     * @param image Bild.
+     * @param size Zielgroesse.
+     * @return skaliertes Bild.
+     */
+    private Image scale(Image image, int size)
+    {
+      if (image == null || image.isDisposed())
+        return null;
+
+      Rectangle bounds = image.getBounds();
+      if (bounds.width <= 1 || bounds.height <= 1)
+        return null;
+
+      if (bounds.width == size && bounds.height == size)
+        return image;
+
+      ImageData data = image.getImageData().scaledTo(size,size);
+      Image scaled = new Image(GUI.getDisplay(),data);
+      this.images.add(scaled);
+      return scaled;
+    }
+
+    /**
+     * Entsorgt die fuer die Vorschau skalierten Bilder.
+     */
+    private void dispose()
+    {
+      for (Image image:this.images)
+      {
+        if (image != null && !image.isDisposed())
+          image.dispose();
+      }
+      this.images.clear();
+    }
+  }
+
+  /**
+   * Liefert die verf\u00fcgbaren Icons.
+   * @return Icons.
+   */
+  private List<IconFile> getIcons()
+  {
+    List<String> names = new ArrayList<String>();
+    addIcons(new File("src/img"),names);
+    addIcons(new File("img"),names);
+    addIcons(new File(Application.getConfig().getWorkDir(),"img"),names);
+    for (Manifest mf:Application.getPluginLoader().getInstalledManifests())
+    {
+      File dir = new File(mf.getPluginDir());
+      addIcons(new File(dir,"img"),names);
+      addIcons(new File(dir,"src/img"),names);
+      addJarIcons(dir,names);
+    }
+
+    Collections.sort(names);
+    List<IconFile> result = new ArrayList<IconFile>();
+    String last = null;
+    for (String name:names)
+    {
+      if (name.equals(last))
+        continue;
+      result.add(new IconFile(name));
+      last = name;
+    }
+    return result;
+  }
+
+  /**
+   * Fuegt Icons aus einem Verzeichnis hinzu.
+   * @param dir Verzeichnis.
+   * @param names Dateinamen.
+   */
+  private void addIcons(File dir, List<String> names)
+  {
+    addIcons(dir,dir,names);
+  }
+
+  /**
+   * Fuegt Icons aus einem Verzeichnis und dessen Unterverzeichnissen hinzu.
+   * @param root Wurzelverzeichnis, relativ zu dem die Icon-Namen gespeichert werden.
+   * @param dir aktuelles Verzeichnis.
+   * @param names Dateinamen.
+   */
+  private void addIcons(File root, File dir, List<String> names)
+  {
+    if (root == null || dir == null || !dir.isDirectory())
+      return;
+
+    File[] files = dir.listFiles();
+    if (files == null)
+      return;
+
+    for (File file:files)
+    {
+      if (file.isDirectory())
+      {
+        addIcons(root,file,names);
+        continue;
+      }
+
+      if (!file.isFile())
+        continue;
+
+      String name = root.toPath().relativize(file.toPath()).toString().replace(File.separatorChar,'/');
+      if (isImageFile(name) && isIconSizeAllowed(file))
+        names.add(name);
+    }
+  }
+
+  /**
+   * Fuegt Icons aus Jar-Dateien eines Plugin-Verzeichnisses hinzu.
+   * @param dir Plugin-Verzeichnis.
+   * @param names Dateinamen.
+   */
+  private void addJarIcons(File dir, List<String> names)
+  {
+    if (dir == null || !dir.isDirectory())
+      return;
+
+    File[] files = dir.listFiles();
+    if (files == null)
+      return;
+
+    for (File file:files)
+    {
+      if (file.isDirectory())
+      {
+        addJarIcons(file,names);
+        continue;
+      }
+
+      if (!file.isFile() || !file.getName().toLowerCase().endsWith(".jar"))
+        continue;
+
+      addJarFileIcons(file,names);
+    }
+  }
+
+  /**
+   * Fuegt Icons aus einer Jar-Datei hinzu.
+   * @param file Jar-Datei.
+   * @param names Dateinamen.
+   */
+  private void addJarFileIcons(File file, List<String> names)
+  {
+    JarFile jar = null;
+    try
+    {
+      jar = new JarFile(file);
+      Enumeration<JarEntry> entries = jar.entries();
+      while (entries.hasMoreElements())
+      {
+        JarEntry entry = entries.nextElement();
+        if (entry == null || entry.isDirectory())
+          continue;
+
+        String name = entry.getName();
+        if (!name.startsWith("img/") || !isImageFile(name))
+          continue;
+
+        String icon = name.substring("img/".length());
+        if (icon.length() == 0)
+          continue;
+
+        InputStream is = null;
+        try
+        {
+          is = jar.getInputStream(entry);
+          if (isIconSizeAllowed(is,name))
+            names.add(icon);
+        }
+        finally
+        {
+          de.willuhn.io.IOUtil.close(is);
+        }
+      }
+    }
+    catch (Exception e)
+    {
+      Logger.warn("unable to inspect jar file " + file + ": " + e.getMessage());
+    }
+    finally
+    {
+      de.willuhn.io.IOUtil.close(jar);
+    }
+  }
+
+  /**
+   * Prueft, ob die Datei ein unterstuetztes Bildformat hat.
+   * @param name Dateiname.
+   * @return true, wenn das Format unterstuetzt wird.
+   */
+  private boolean isImageFile(String name)
+  {
+    if (name == null)
+      return false;
+
+    String lower = name.toLowerCase();
+    return lower.endsWith(".png") || lower.endsWith(".gif") || lower.endsWith(".jpg") || lower.endsWith(".jpeg") || lower.endsWith(".bmp");
+  }
+
+  /**
+   * Prueft, ob das Bild maximal 512x512 Pixel gross ist.
+   * @param file Bilddatei.
+   * @return true, wenn es als Icon angeboten werden darf.
+   */
+  private boolean isIconSizeAllowed(File file)
+  {
+    try
+    {
+      org.eclipse.swt.graphics.ImageData data = new org.eclipse.swt.graphics.ImageData(file.getAbsolutePath());
+      return isIconSizeAllowed(data);
+    }
+    catch (Exception e)
+    {
+      Logger.warn("unable to inspect icon file " + file + ": " + e.getMessage());
+      return false;
+    }
+  }
+
+  /**
+   * Prueft, ob ein Bild maximal 512x512 Pixel gross ist.
+   * @param is Bilddaten.
+   * @param name Name fuer das Logging.
+   * @return true, wenn es als Icon angeboten werden darf.
+   */
+  private boolean isIconSizeAllowed(InputStream is, String name)
+  {
+    try
+    {
+      org.eclipse.swt.graphics.ImageData data = new org.eclipse.swt.graphics.ImageData(is);
+      return isIconSizeAllowed(data);
+    }
+    catch (Exception e)
+    {
+      Logger.warn("unable to inspect icon file " + name + ": " + e.getMessage());
+      return false;
+    }
+  }
+
+  /**
+   * Prueft die Bildgroesse.
+   * @param data Bilddaten.
+   * @return true, wenn die Groesse erlaubt ist.
+   */
+  private boolean isIconSizeAllowed(org.eclipse.swt.graphics.ImageData data)
+  {
+    return data != null && data.width <= 512 && data.height <= 512;
+  }
+
+  /**
+   * Icon-Datei fuer den Auswahl-Dialog.
+   */
+  public static class IconFile implements GenericObject
+  {
+    private String name;
+
+    public IconFile(String name)
+    {
+      this.name = StringUtils.trimToNull(name);
+    }
+
+    public String getName()
+    {
+      return this.name;
+    }
+
+    public Object getAttribute(String name) throws RemoteException
+    {
+      if ("preview".equals(name))
+        return "";
+      if ("name".equals(name))
+        return getName();
+      return null;
+    }
+
+    public String[] getAttributeNames() throws RemoteException
+    {
+      return new String[] {"name"};
+    }
+
+    public String getID() throws RemoteException
+    {
+      return this.name;
+    }
+
+    public String getPrimaryAttribute() throws RemoteException
+    {
+      return "name";
+    }
+
+    public boolean equals(GenericObject other) throws RemoteException
+    {
+      return other != null && getID().equals(other.getID());
+    }
+  }
+}

--- a/src/de/willuhn/jameica/gui/internal/views/Settings.java
+++ b/src/de/willuhn/jameica/gui/internal/views/Settings.java
@@ -131,6 +131,9 @@ public class Settings extends AbstractView implements Extendable
     lnfGroup.addInput(control.getSystray());
     lnfGroup.addInput(control.getMinimizeToSystray());
 
+    lnfGroup.addHeadline(i18n.tr("Symbolleiste"));
+    lnfGroup.addPart(control.getIconBarSettings());
+
     //
 		/////////////////////////////////////////////////////////////////
 

--- a/src/de/willuhn/jameica/gui/parts/TablePart.java
+++ b/src/de/willuhn/jameica/gui/parts/TablePart.java
@@ -106,6 +106,7 @@ public class TablePart extends AbstractTablePart
   //////////////////////////////////////////////////////////
   // Flags
   private boolean enabled               = true;
+  private boolean sortable              = true;
   //////////////////////////////////////////////////////////
 
   //////////////////////////////////////////////////////////
@@ -621,16 +622,19 @@ public class TablePart extends AbstractTablePart
       
       
       // Sortierung
-      final int p = i;
-      col.addListener(SWT.Selection, new Listener() {
-        public void handleEvent(Event e)
-        {
-          // Wenn wir vorher schonmal nach dieser Spalte
-          // sortiert haben, kehren wir die Sortierung um
-          direction = !(direction && p == sortedBy);
-          orderBy(p);
-        }
-      });
+      if (this.sortable)
+      {
+        final int p = i;
+        col.addListener(SWT.Selection, new Listener() {
+          public void handleEvent(Event e)
+          {
+            // Wenn wir vorher schonmal nach dieser Spalte
+            // sortiert haben, kehren wir die Sortierung um
+            direction = !(direction && p == sortedBy);
+            orderBy(p);
+          }
+        });
+      }
 
 
       // Wenn Ausrichtung explizit angegeben, dann nehmen wir die
@@ -1293,6 +1297,15 @@ public class TablePart extends AbstractTablePart
   public boolean isEnabled()
   {
     return this.enabled;
+  }
+  
+  /**
+   * Legt fest, ob die Tabelle per Klick auf die Spalten sortiert werden kann.
+   * @param sortable true, wenn sortierbar.
+   */
+  public void setSortable(boolean sortable)
+  {
+    this.sortable = sortable;
   }
   
   /**

--- a/src/de/willuhn/jameica/gui/util/SWTUtil.java
+++ b/src/de/willuhn/jameica/gui/util/SWTUtil.java
@@ -350,6 +350,8 @@ public class SWTUtil {
       {
         String sub = path != null ? path + File.separator : "";
         File file = new File(sub + filename);
+        if (!file.isFile() || !file.canRead())
+          file = new File(new File(Application.getConfig().getWorkDir(),"img"),sub + filename);
         if (file.isFile() && file.canRead())
           is = new BufferedInputStream(new FileInputStream(file));
       }

--- a/src/de/willuhn/jameica/plugin/PluginLoader.java
+++ b/src/de/willuhn/jameica/plugin/PluginLoader.java
@@ -435,7 +435,7 @@ public final class PluginLoader
         {
           Class c = manifest.getClassLoader().load(ext[i].getClassname());
           BeanService beanService = Application.getBootLoader().getBootable(BeanService.class);
-          ExtensionRegistry.register((Extension) beanService.get(c), ext[i].getExtendableIDs());
+          ExtensionRegistry.register((Extension) beanService.get(c), ext[i].getExtendableIDs(), manifest.getName());
           Logger.info("  register " + c.getName());
         }
         catch (Exception e)


### PR DESCRIPTION
Anbei ein PR, der Jameica eine Symbolleiste hinzufügt.

Die Symbolleiste kann auf Menüeinträge, Einträge im Navtree und auf Lesezeichen verweisen.


Um die Plugin-Herkunft der Menü- und Navtree-Einträge anzeigen zu lassen, musste die Extension-Registrierung und  Menüregistrierung angepasst werden. Sie speichern nun die Plugin-Herkunft. 


Neue zentrale Klassen

  - de.willuhn.jameica.gui.IconBar
      - Rendert die Symbolleiste als SWT ToolBar.
      - Verwaltet Kontextmenü, Ausführung der Actions, Icon-Skalierung, Spacer und Bookmark-Cleanup.

  - de.willuhn.jameica.gui.IconBarEntry
      - Persistierbares Modell für Einträge der Symbolleiste.
      - Unterstützte Typen: navigation, menu, bookmark, spacer.
      - Entfernt Mnemonic-& aus sichtbaren Namen.

  - de.willuhn.jameica.gui.IconBarSettings
      - Persistenz über Settings.
      - Speichert Sichtbarkeit, Größe und Eintragsliste.
      - Größen: small, medium, large.

  - de.willuhn.jameica.gui.internal.parts.IconBarSettingsPart
      - Konfiguration im Tab Look & Feel.

  - de.willuhn.jameica.gui.internal.action.IconBarToggle
      - Action zum Ein-/Ausblenden der Symbolleiste.

  - de.willuhn.jameica.gui.dialogs.SearchableListDialog
      - Neuer spezialisierter Dialog mit Suchfeld, Tabellen-Spalten und optionalem TableFormatter.
      - ListDialog wurde wieder generisch belassen.


