### PR TITLE
TablePart bei Sortierung checked Status erhalten

### DIFF
--- a/src/de/willuhn/jameica/gui/parts/TablePart.java
+++ b/src/de/willuhn/jameica/gui/parts/TablePart.java
@@ -1354,17 +1354,29 @@ public class TablePart extends AbstractTablePart
     table.removeAll();
 
     // Und schreiben sie sortiert neu
-    Item sort = null;
-    for (int i=0;i<l.size();++i)
+    try
     {
-      sort = l.get(i);
-      final TableItem item = new TableItem(table,SWT.NONE,i);
-      item.setData(sort.data);
-      item.setText(textTable.get(sort.data));
-      if (tableFormatter != null)
-        tableFormatter.format(item);
+      List<?> checkedItems = getItems();
+
+      Item sort = null;
+      for (int i=0;i<l.size();++i)
+      {
+        sort = l.get(i);
+        final TableItem item = new TableItem(table,SWT.NONE,i);
+        item.setData(sort.data);
+        item.setText(textTable.get(sort.data));
+        if (tableFormatter != null)
+          tableFormatter.format(item);
+      }
+      if (checkable)
+      {
+        setChecked(checkedItems.toArray(), true);
+      }
+    } catch (RemoteException e)
+    {
+      Logger.error("Fehler beim Sortieren");
     }
-    
+
     if (selection != null)
     {
       if (selection instanceof Object[])


### PR DESCRIPTION
Wenn man einen TablePart mit Checkboxes neu sortiert, sind alle Checkboxes abgewählt. Durch diesen PR wird der Status nach dem Sortieren wiederhergestellt.