### PR TITLE
Add more context in case jameicas plugin.xml cannot be loaded

### DIFF
--- a/src/de/willuhn/jameica/system/Application.java
+++ b/src/de/willuhn/jameica/system/Application.java
@@ -479,7 +479,7 @@ public final class Application {
       }
       catch (Exception e)
       {
-        app.startupError(e);
+        app.startupError(new Exception("Cannot read jameica application manifest", e));
       }
     }
     return app.manifest;


### PR DESCRIPTION
I was playing around with launching hibiscus (and obviously made a mistake there). The error message although was pointing to plugin.xml and I was thinking, it was in regard to hibiscus' plugin.xml. This additional context on the exception should make that more clear.